### PR TITLE
8268531: mark SDTProbesGNULinuxTest as ignoring external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
+++ b/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, Red Hat, Inc.
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
+++ b/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
@@ -27,6 +27,7 @@
  * @bug 7170638
  * @summary Test SDT probes available on GNU/Linux when DTRACE_ENABLED
  * @requires os.family == "linux"
+ * @requires vm.flagless
  *
  * @library /test/lib
  * @run driver SDTProbesGNULinuxTest


### PR DESCRIPTION
(recreating openjdk/jdk#4453 against jdk17)

Hi all,

could you please review this patch that adds `@requires vm.flagless` to `SDTProbesGNULinuxTest` test as it ignores all external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268531](https://bugs.openjdk.java.net/browse/JDK-8268531): mark SDTProbesGNULinuxTest as ignoring external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/1.diff">https://git.openjdk.java.net/jdk17/pull/1.diff</a>

</details>
