### PR TITLE
8267448: Add "ulimit -a" to environment.html

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -62,6 +62,7 @@ environment=\
   users.current users.logged users.last \
   disk \
   env \
+  ulimit \
   system.dmesg system.sysctl \
   process.top process.ps \
   memory.free memory.vmstat.default memory.vmstat.statistics \
@@ -82,6 +83,10 @@ disk.app=df
 disk.args=-h
 
 env.app=env
+
+ulimit.app=bash
+ulimit.args=-c\0ulimit -a
+ulimit.args.delimiter=\0
 
 system.dmesg.app=dmesg
 system.sysctl.app=sysctl

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -71,6 +71,7 @@ environment=\
   users.current users.logged users.last \
   disk \
   env \
+  ulimit \
   system.dmesg system.sysctl \
   process.ps process.top \
   memory.vmstat \
@@ -90,6 +91,10 @@ disk.app=df
 disk.args=-h
 
 env.app=env
+
+ulimit.app=bash
+ulimit.args=-c\0ulimit -a
+ulimit.args.delimiter=\0
 
 system.dmesg.app=dmesg
 system.sysctl.app=sysctl

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -66,6 +66,7 @@ environment=\
   users.current users.logged \
   disk \
   env \
+  ulimit \
   system.events.system system.events.application system.os \
   process.top process.ps process.tasklist \
   memory.free memory.vmstat.default memory.vmstat.statistics \
@@ -83,6 +84,10 @@ disk.app=df
 disk.args=-h
 
 env.app=env
+
+ulimit.app=bash
+ulimit.args=-c\0ulimit -a
+ulimit.args.delimiter=\0
 
 system.events.app=powershell
 system.events.delimiter=\0

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
(recreating openjdk/jdk#4451 against jdk17)

Hi all,

could you please review this small patch that does $subj?

Thanks,
-- Igor

attn: @plummercj

/cc hotspot-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267448](https://bugs.openjdk.java.net/browse/JDK-8267448): Add "ulimit -a" to environment.html


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 83e0e238cef6d65402c1e2f59e9e546c912329f1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/2.diff">https://git.openjdk.java.net/jdk17/pull/2.diff</a>

</details>
