### PR TITLE
8268525: Some new memory leak after JDK-8248268 and JDK-8255557

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -435,50 +435,54 @@ final class CipherCore {
 
         byte[] keyBytes = getKeyBytes(key);
         byte[] ivBytes = null;
-        if (params != null) {
-            if (params instanceof IvParameterSpec) {
-                ivBytes = ((IvParameterSpec) params).getIV();
-                if ((ivBytes == null) || (ivBytes.length != blockSize)) {
+        try {
+            if (params != null) {
+                if (params instanceof IvParameterSpec) {
+                    ivBytes = ((IvParameterSpec) params).getIV();
+                    if ((ivBytes == null) || (ivBytes.length != blockSize)) {
+                        throw new InvalidAlgorithmParameterException
+                                ("Wrong IV length: must be " + blockSize +
+                                        " bytes long");
+                    }
+                } else if (params instanceof RC2ParameterSpec) {
+                    ivBytes = ((RC2ParameterSpec) params).getIV();
+                    if ((ivBytes != null) && (ivBytes.length != blockSize)) {
+                        throw new InvalidAlgorithmParameterException
+                                ("Wrong IV length: must be " + blockSize +
+                                        " bytes long");
+                    }
+                } else {
                     throw new InvalidAlgorithmParameterException
-                        ("Wrong IV length: must be " + blockSize +
-                            " bytes long");
+                            ("Unsupported parameter: " + params);
                 }
-            } else if (params instanceof RC2ParameterSpec) {
-                ivBytes = ((RC2ParameterSpec) params).getIV();
-                if ((ivBytes != null) && (ivBytes.length != blockSize)) {
+            }
+            if (cipherMode == ECB_MODE) {
+                if (ivBytes != null) {
                     throw new InvalidAlgorithmParameterException
-                        ("Wrong IV length: must be " + blockSize +
-                            " bytes long");
+                            ("ECB mode cannot use IV");
                 }
-            } else {
-                throw new InvalidAlgorithmParameterException
-                    ("Unsupported parameter: " + params);
+            } else if (ivBytes == null) {
+                if (decrypting) {
+                    throw new InvalidAlgorithmParameterException("Parameters "
+                            + "missing");
+                }
+
+                if (random == null) {
+                    random = SunJCE.getRandom();
+                }
+
+                ivBytes = new byte[blockSize];
+                random.nextBytes(ivBytes);
             }
+
+            buffered = 0;
+            diffBlocksize = blockSize;
+
+            String algorithm = key.getAlgorithm();
+            cipher.init(decrypting, algorithm, keyBytes, ivBytes);
+        } finally {
+            Arrays.fill(keyBytes, (byte)0);
         }
-        if (cipherMode == ECB_MODE) {
-            if (ivBytes != null) {
-                throw new InvalidAlgorithmParameterException
-                    ("ECB mode cannot use IV");
-            }
-        } else if (ivBytes == null) {
-            if (decrypting) {
-                throw new InvalidAlgorithmParameterException("Parameters "
-                    + "missing");
-            }
-
-            if (random == null) {
-                random = SunJCE.getRandom();
-            }
-
-            ivBytes = new byte[blockSize];
-            random.nextBytes(ivBytes);
-        }
-
-        buffered = 0;
-        diffBlocksize = blockSize;
-
-        String algorithm = key.getAlgorithm();
-        cipher.init(decrypting, algorithm, keyBytes, ivBytes);
     }
 
     void init(int opmode, Key key, AlgorithmParameters params,

--- a/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
@@ -25,6 +25,8 @@
 
 package com.sun.crypto.provider;
 
+import jdk.internal.access.SharedSecrets;
+
 import java.security.Key;
 import java.security.PublicKey;
 import java.security.PrivateKey;
@@ -111,11 +113,11 @@ final class ConstructKeys {
             throws InvalidKeyException, NoSuchAlgorithmException {
         PrivateKey key = null;
 
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encodedKey);
         try {
             KeyFactory keyFactory =
                 KeyFactory.getInstance(encodedKeyAlgorithm,
                     SunJCE.getInstance());
-            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encodedKey);
             return keyFactory.generatePrivate(keySpec);
         } catch (NoSuchAlgorithmException nsae) {
             // Try to see whether there is another
@@ -123,8 +125,6 @@ final class ConstructKeys {
             try {
                 KeyFactory keyFactory =
                     KeyFactory.getInstance(encodedKeyAlgorithm);
-                PKCS8EncodedKeySpec keySpec =
-                    new PKCS8EncodedKeySpec(encodedKey);
                 key = keyFactory.generatePrivate(keySpec);
             } catch (NoSuchAlgorithmException nsae2) {
                 throw new NoSuchAlgorithmException("No installed providers " +
@@ -142,6 +142,8 @@ final class ConstructKeys {
                 new InvalidKeyException("Cannot construct private key");
             ike.initCause(ikse);
             throw ike;
+        } finally {
+            SharedSecrets.getJavaSecuritySpecAccess().clearEncodedKeySpec(keySpec);
         }
 
         return key;

--- a/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
@@ -50,24 +50,18 @@ import javax.crypto.spec.SecretKeySpec;
  */
 
 final class ConstructKeys {
-    /**
-     * Construct a public key from its encoding.
-     *
-     * @param encodedKey the encoding of a public key.
-     *
-     * @param encodedKeyAlgorithm the algorithm the encodedKey is for.
-     *
-     * @return a public key constructed from the encodedKey.
-     */
+
     private static final PublicKey constructPublicKey(byte[] encodedKey,
-            String encodedKeyAlgorithm)
+            int ofs, int len, String encodedKeyAlgorithm)
             throws InvalidKeyException, NoSuchAlgorithmException {
         PublicKey key = null;
+        byte[] keyBytes = (ofs == 0 && encodedKey.length == len)
+                ? encodedKey : Arrays.copyOfRange(encodedKey, ofs, ofs + len);
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(keyBytes);
         try {
             KeyFactory keyFactory =
                 KeyFactory.getInstance(encodedKeyAlgorithm,
                     SunJCE.getInstance());
-            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encodedKey);
             key = keyFactory.generatePublic(keySpec);
         } catch (NoSuchAlgorithmException nsae) {
             // Try to see whether there is another
@@ -75,8 +69,6 @@ final class ConstructKeys {
             try {
                 KeyFactory keyFactory =
                     KeyFactory.getInstance(encodedKeyAlgorithm);
-                X509EncodedKeySpec keySpec =
-                    new X509EncodedKeySpec(encodedKey);
                 key = keyFactory.generatePublic(keySpec);
             } catch (NoSuchAlgorithmException nsae2) {
                 throw new NoSuchAlgorithmException("No installed providers " +
@@ -99,21 +91,13 @@ final class ConstructKeys {
         return key;
     }
 
-    /**
-     * Construct a private key from its encoding.
-     *
-     * @param encodedKey the encoding of a private key.
-     *
-     * @param encodedKeyAlgorithm the algorithm the wrapped key is for.
-     *
-     * @return a private key constructed from the encodedKey.
-     */
     private static final PrivateKey constructPrivateKey(byte[] encodedKey,
-            String encodedKeyAlgorithm)
+            int ofs, int len, String encodedKeyAlgorithm)
             throws InvalidKeyException, NoSuchAlgorithmException {
         PrivateKey key = null;
-
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encodedKey);
+        byte[] keyBytes = (ofs == 0 && encodedKey.length == len)
+                ? encodedKey : Arrays.copyOfRange(encodedKey, ofs, ofs + len);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
         try {
             KeyFactory keyFactory =
                 KeyFactory.getInstance(encodedKeyAlgorithm,
@@ -144,20 +128,14 @@ final class ConstructKeys {
             throw ike;
         } finally {
             SharedSecrets.getJavaSecuritySpecAccess().clearEncodedKeySpec(keySpec);
+            if (keyBytes != encodedKey) {
+                Arrays.fill(keyBytes, (byte)0);
+            }
         }
 
         return key;
     }
 
-    /**
-     * Construct a secret key from its encoding.
-     *
-     * @param encodedKey the encoding of a secret key.
-     *
-     * @param encodedKeyAlgorithm the algorithm the secret key is for.
-     *
-     * @return a secret key constructed from the encodedKey.
-     */
     private static final SecretKey constructSecretKey(byte[] encodedKey,
             int ofs, int len, String encodedKeyAlgorithm) {
         return (new SecretKeySpec(encodedKey, ofs, len, encodedKeyAlgorithm));
@@ -172,35 +150,14 @@ final class ConstructKeys {
     static final Key constructKey(byte[] encoding, int ofs, int len,
             String keyAlgorithm, int keyType)
             throws InvalidKeyException, NoSuchAlgorithmException {
-        switch (keyType) {
-        case Cipher.SECRET_KEY:
-            try {
-                return ConstructKeys.constructSecretKey(encoding, ofs, len,
-                        keyAlgorithm);
-            } finally {
-                Arrays.fill(encoding, ofs, len, (byte)0);
-            }
-        case Cipher.PRIVATE_KEY:
-            byte[] encoding2 = encoding;
-            try {
-                if (ofs != 0 || len != encoding.length) {
-                    encoding2 = Arrays.copyOfRange(encoding, ofs, ofs + len);
-                }
-                return ConstructKeys.constructPrivateKey(encoding2,
-                        keyAlgorithm);
-            } finally {
-                Arrays.fill(encoding, ofs, len, (byte)0);
-                if (encoding2 != encoding) {
-                    Arrays.fill(encoding2, (byte)0);
-                }
-            }
-        case Cipher.PUBLIC_KEY:
-            if (ofs != 0 || len != encoding.length) {
-                encoding = Arrays.copyOfRange(encoding, ofs, ofs + len);
-            }
-            return ConstructKeys.constructPublicKey(encoding, keyAlgorithm);
-        default:
-            throw new NoSuchAlgorithmException("Unsupported key type");
-        }
+        return switch (keyType) {
+            case Cipher.SECRET_KEY -> ConstructKeys.constructSecretKey(
+                    encoding, ofs, len, keyAlgorithm);
+            case Cipher.PRIVATE_KEY -> ConstructKeys.constructPrivateKey(
+                    encoding, ofs, len, keyAlgorithm);
+            case Cipher.PUBLIC_KEY -> ConstructKeys.constructPublicKey(
+                    encoding, ofs, len, keyAlgorithm);
+            default -> throw new NoSuchAlgorithmException("Unsupported key type");
+        };
     }
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -163,7 +163,13 @@ abstract class GaloisCounterMode extends CipherSpi {
         reInit = false;
 
         // always encrypt mode for embedded cipher
-        blockCipher.init(false, key.getAlgorithm(), keyValue);
+        try {
+            blockCipher.init(false, key.getAlgorithm(), keyValue);
+        } finally {
+            if (!encryption) {
+                Arrays.fill(keyValue, (byte) 0);
+            }
+        }
     }
 
     @Override

--- a/src/java.base/share/classes/com/sun/crypto/provider/KWUtil.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KWUtil.java
@@ -124,6 +124,7 @@ class KWUtil {
             }
         }
         System.arraycopy(buffer, 0, icvOut, 0, SEMI_BLKSIZE);
+        Arrays.fill(buffer, (byte)0);
         return inLen - SEMI_BLKSIZE;
     }
 }


### PR DESCRIPTION
Remove newly leaked memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268525](https://bugs.openjdk.java.net/browse/JDK-8268525): Some new memory leak after JDK-8248268 and JDK-8255557


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**) ⚠️ Review applies to 923756084d248edcaab80790f9133c7a52ca299c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/3.diff">https://git.openjdk.java.net/jdk17/pull/3.diff</a>

</details>
