### PR TITLE
8268541: mark hotspot serviceability/sa tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
@@ -38,6 +38,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @requires vm.hasSA
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @requires os.family=="windows" | os.family == "linux" | os.family == "mac"
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver TestJhsdbJstackLineNumbers
  */


### PR DESCRIPTION
Hi all,

could you please review this one-liner that adds `@requires vm.flagless` to `serviceability/sa/TestJhsdbJstackLineNumbers.java` as it ignores external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268541](https://bugs.openjdk.java.net/browse/JDK-8268541): mark hotspot serviceability/sa tests which ignore external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/6.diff">https://git.openjdk.java.net/jdk17/pull/6.diff</a>

</details>
