### PR TITLE
8268563: mark hotspot serviceability/jvmti tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
@@ -29,6 +29,7 @@
  *          at ONLOAD and LIVE phases
  * @requires vm.jvmti
  * @requires vm.cds
+ * @requires vm.flagless
  * @library /test/lib
  * @compile CanGenerateAllClassHook.java
  * @run main/othervm/native CanGenerateAllClassHook

--- a/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
@@ -31,6 +31,7 @@ import jdk.test.lib.process.ProcessTools;
  * @bug 8075030
  * @summary JvmtiEnv::GetObjectSize reports incorrect java.lang.Class instance size
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
@@ -26,6 +26,7 @@
  * @library /test/lib
  * @summary Test that redefinition reuses metaspace blocks that are freed
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          jdk.jartool/sun.tools.jar

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
@@ -27,6 +27,7 @@
  * @summary Test has_previous_versions flag and processing during class unloading.
  * @requires vm.jvmti
  * @requires vm.opt.final.ClassUnloading
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RetransformClassesZeroLength.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RetransformClassesZeroLength.java
@@ -26,6 +26,7 @@
  * @bug 8198393
  * @summary Instrumentation.retransformClasses(new Class[0]) should be NOP
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.instrument
  * @compile RetransformClassesZeroLength.java

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TransformerDeadlockTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TransformerDeadlockTest.java
@@ -27,6 +27,7 @@
  * @summary Test recursively retransforms the same class. The test hangs if
  *          a deadlock happens.
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.instrument
  * @compile TransformerDeadlockTest.java


### PR DESCRIPTION
Hi all,

could you please review this one-liner that adds `@requires vm.flagless` to 6 `serviceability/jvmti` tests that ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268563](https://bugs.openjdk.java.net/browse/JDK-8268563): mark hotspot serviceability/jvmti tests which ignore external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/7.diff">https://git.openjdk.java.net/jdk17/pull/7.diff</a>

</details>
