### PR TITLE
8268564: mark hotspot serviceability/attach tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8054823
  * @summary Tests the setFlag and printFlag attach command
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
@@ -25,11 +25,12 @@
  * @test
  * @bug 7162400
  * @summary Regression test for attach issue where stale pid files in /tmp lead to connection issues
+ * @requires os.family != "windows"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  * @modules jdk.attach/sun.tools.attach
  * @library /test/lib
- * @requires os.family != "windows"
  * @run driver AttachWithStalePidFile
  */
 


### PR DESCRIPTION
Hi all,

could you please review this one-liner that adds `@requires vm.flagless` to 2 `serviceability/attach` tests that ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268564](https://bugs.openjdk.java.net/browse/JDK-8268564): mark hotspot serviceability/attach tests which ignore external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/8.diff">https://git.openjdk.java.net/jdk17/pull/8.diff</a>

</details>
