### PR TITLE
8268349: Provide clear run-time warnings about Security Manager deprecation

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -61,7 +61,6 @@ import java.util.Properties;
 import java.util.PropertyPermission;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -391,7 +390,7 @@ public final class System {
             // security manager not allowed
             if (sm != null) {
                 throw new UnsupportedOperationException(
-                    "Runtime configured to disallow security manager");
+                    "The Security Manager API is deprecated and will be removed in a future release");
             }
         }
     }
@@ -2213,8 +2212,8 @@ public final class System {
         if (needWarning) {
             System.err.printf("""
                     WARNING: A Security Manager has been enabled on the command line
-                    WARNING: java.lang.SecurityManager is deprecated and will be removed in a future release
-                    WARNING: -Djava.security.manager%s will have no effect when java.lang.SecurityManager is removed
+                    WARNING: The Security Manager API is deprecated and will be removed in a future release
+                    WARNING: -Djava.security.manager%s will have no effect when the API is removed
                     """, smProp.isEmpty() ? "" : ("=" + smProp));
         }
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -381,16 +381,16 @@ public final class System {
             String signature = caller.getName() + " (" + codeSource(caller) + ")";
             originalErrStream.printf("""
                     WARNING: A terminally deprecated method in java.lang.System has been called
-                    WARNING: java.lang.System::setSecurityManager has been called by %s
+                    WARNING: System::setSecurityManager has been called by %s
                     WARNING: Please consider reporting this to the maintainers of %s
-                    WARNING: java.lang.System::setSecurityManager will be removed in a future release
+                    WARNING: System::setSecurityManager will be removed in a future release
                     """, signature, caller.getName());
             implSetSecurityManager(sm);
         } else {
             // security manager not allowed
             if (sm != null) {
                 throw new UnsupportedOperationException(
-                    "The Security Manager API is deprecated and will be removed in a future release");
+                    "The Security Manager is deprecated and will be removed in a future release");
             }
         }
     }
@@ -2210,11 +2210,9 @@ public final class System {
         }
 
         if (needWarning) {
-            System.err.printf("""
-                    WARNING: A Security Manager has been enabled on the command line
-                    WARNING: The Security Manager API is deprecated and will be removed in a future release
-                    WARNING: -Djava.security.manager%s will have no effect when the API is removed
-                    """, smProp.isEmpty() ? "" : ("=" + smProp));
+            System.err.println("""
+                    WARNING: A command line option has enabled the Security Manager
+                    WARNING: The Security Manager is deprecated and will be removed in a future release""");
         }
 
         originalErrStream = System.err;

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -328,13 +328,7 @@ public final class System {
     private static native void setErr0(PrintStream err);
 
     // Remember original System.err. setSecurityManager() warning goes here
-    private static PrintStream oldErrStream = null;
-
-    private static class CallerHolder {
-        // Remember callers of setSecurityManager() here so that warning
-        // is only printed once for each different caller
-        final static Map<String, Boolean> callersOfSSM = new WeakHashMap<>();
-    }
+    private static volatile @Stable PrintStream originalErrStream = null;
 
     private static URL codeSource(Class<?> clazz) {
         PrivilegedAction<ProtectionDomain> pa = clazz::getProtectionDomain;
@@ -386,15 +380,12 @@ public final class System {
         if (allowSecurityManager()) {
             var caller = Reflection.getCallerClass();
             String signature = caller.getName() + " (" + codeSource(caller) + ")";
-            if (!CallerHolder.callersOfSSM.containsKey(signature)) {
-                oldErrStream.printf("""
-                        WARNING: A terminally deprecated method in java.lang.System has been called
-                        WARNING: java.lang.System::setSecurityManager has been called by %s
-                        WARNING: Please consider reporting this to the maintainers of %s
-                        WARNING: java.lang.System::setSecurityManager will be removed in a future release
-                        """, signature, caller.getName());
-                CallerHolder.callersOfSSM.put(signature, true);
-            }
+            originalErrStream.printf("""
+                    WARNING: A terminally deprecated method in java.lang.System has been called
+                    WARNING: java.lang.System::setSecurityManager has been called by %s
+                    WARNING: Please consider reporting this to the maintainers of %s
+                    WARNING: java.lang.System::setSecurityManager will be removed in a future release
+                    """, signature, caller.getName());
             implSetSecurityManager(sm);
         } else {
             // security manager not allowed
@@ -2177,6 +2168,7 @@ public final class System {
         Unsafe.getUnsafe().ensureClassInitialized(StringConcatFactory.class);
 
         String smProp = System.getProperty("java.security.manager");
+        boolean needWarning = false;
         if (smProp != null) {
             switch (smProp) {
                 case "disallow":
@@ -2189,11 +2181,7 @@ public final class System {
                 case "default":
                     implSetSecurityManager(new SecurityManager());
                     allowSecurityManager = MAYBE;
-                    System.err.printf("""
-                            WARNING: The Security Manager has been enabled on the command line (-Djava.security.manager%1$s)
-                            WARNING: The Security Manager is deprecated and will be removed in a future release
-                            WARNING: -Djava.security.manager%1$s will have no effect when the Security Manager is removed
-                            """, smProp.isEmpty() ? "" : ("=" + smProp));
+                    needWarning = true;
                     break;
                 default:
                     try {
@@ -2212,11 +2200,7 @@ public final class System {
                         ctor.setAccessible(true);
                         SecurityManager sm = (SecurityManager) ctor.newInstance();
                         implSetSecurityManager(sm);
-                        System.err.printf("""
-                                WARNING: A Security Manager implementation has been enabled on the command line
-                                WARNING: java.lang.SecurityManager is deprecated and will be removed in a future release
-                                WARNING: -Djava.security.manager=%s will have no effect when java.lang.SecurityManager is removed
-                                """, smProp);
+                        needWarning = true;
                     } catch (Exception e) {
                         throw new InternalError("Could not create SecurityManager", e);
                     }
@@ -2226,7 +2210,15 @@ public final class System {
             allowSecurityManager = MAYBE;
         }
 
-        oldErrStream = System.err;
+        if (needWarning) {
+            System.err.printf("""
+                    WARNING: A Security Manager has been enabled on the command line
+                    WARNING: java.lang.SecurityManager is deprecated and will be removed in a future release
+                    WARNING: -Djava.security.manager%s will have no effect when java.lang.SecurityManager is removed
+                    """, smProp.isEmpty() ? "" : ("=" + smProp));
+        }
+
+        originalErrStream = System.err;
 
         // initializing the system class loader
         VM.initLevel(3);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -326,8 +326,8 @@ public final class System {
     private static native void setOut0(PrintStream out);
     private static native void setErr0(PrintStream err);
 
-    // Remember original System.err. setSecurityManager() warning goes here
-    private static volatile @Stable PrintStream originalErrStream = null;
+    // Remember initial System.err. setSecurityManager() warning goes here
+    private static volatile @Stable PrintStream initialErrStream;
 
     private static URL codeSource(Class<?> clazz) {
         PrivilegedAction<ProtectionDomain> pa = clazz::getProtectionDomain;
@@ -379,7 +379,7 @@ public final class System {
         if (allowSecurityManager()) {
             var caller = Reflection.getCallerClass();
             String signature = caller.getName() + " (" + codeSource(caller) + ")";
-            originalErrStream.printf("""
+            initialErrStream.printf("""
                     WARNING: A terminally deprecated method in java.lang.System has been called
                     WARNING: System::setSecurityManager has been called by %s
                     WARNING: Please consider reporting this to the maintainers of %s
@@ -2215,7 +2215,7 @@ public final class System {
                     WARNING: The Security Manager is deprecated and will be removed in a future release""");
         }
 
-        originalErrStream = System.err;
+        initialErrStream = System.err;
 
         // initializing the system class loader
         VM.initLevel(3);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -377,14 +377,20 @@ public final class System {
     @CallerSensitive
     public static void setSecurityManager(@SuppressWarnings("removal") SecurityManager sm) {
         if (allowSecurityManager()) {
-            var caller = Reflection.getCallerClass();
-            String signature = caller.getName() + " (" + codeSource(caller) + ")";
+            var callerClass = Reflection.getCallerClass();
+            URL url = codeSource(callerClass);
+            final String source;
+            if (url == null) {
+                source = callerClass.getName();
+            } else {
+                source = callerClass.getName() + " (" + url + ")";
+            }
             initialErrStream.printf("""
                     WARNING: A terminally deprecated method in java.lang.System has been called
                     WARNING: System::setSecurityManager has been called by %s
                     WARNING: Please consider reporting this to the maintainers of %s
                     WARNING: System::setSecurityManager will be removed in a future release
-                    """, signature, caller.getName());
+                    """, source, callerClass.getName());
             implSetSecurityManager(sm);
         } else {
             // security manager not allowed

--- a/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
@@ -36,6 +36,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,15 +45,11 @@ import java.util.function.Supplier;
 import java.lang.System.LoggerFinder;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
-import jdk.internal.logger.SimpleConsoleLogger;
 
 /**
  * @test
@@ -202,6 +199,10 @@ public class LoggerFinderLoaderTest {
         }
     }
 
+    private static String withoutWarning(String in) {
+        return in.lines().filter(s -> !s.startsWith("WARNING:")).collect(Collectors.joining());
+    }
+
     static LoggerFinder getLoggerFinder(Class<?> expectedClass,
             String errorPolicy, boolean singleton) {
         LoggerFinder provider = null;
@@ -235,12 +236,7 @@ public class LoggerFinderLoaderTest {
                     }
                 } else if ("QUIET".equals(errorPolicy.toUpperCase(Locale.ROOT))) {
                     String warning = ErrorStream.errorStream.peek();
-                    String smDeprecationWarning
-                            = "WARNING: java.lang.System::setSecurityManager is deprecated and will be removed in a future release."
-                            + System.getProperty("line.separator");
-                    if (warning.startsWith(smDeprecationWarning)) {
-                        warning = warning.substring(smDeprecationWarning.length());
-                    }
+                    warning = withoutWarning(warning);
                     if (!warning.isEmpty()) {
                         throw new RuntimeException("Unexpected error message found: "
                                 + ErrorStream.errorStream.peek());

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -42,34 +42,38 @@ public class SecurityManagerWarnings {
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
                     .shouldNotContain("-Djava.security.manager")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release")
-                    .shouldNotMatch("(?s)setSecurityManager will be removed.*setSecurityManager will be removed"); // only one "will be removed" warning
+                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+
             run("allow")
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
                     .shouldNotContain("-Djava.security.manager")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release")
-                    .shouldNotMatch("(?s)setSecurityManager will be removed.*setSecurityManager will be removed"); // only one "will be removed" warning
+                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+
             run("disallow")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
                     .shouldNotContain("-Djava.security.manager")
                     .shouldContain("UnsupportedOperationException");
+
             run("SecurityManagerWarnings$MySM")
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release")
-                    .shouldNotMatch("(?s)setSecurityManager will be removed.*setSecurityManager will be removed"); // only one "will be removed" warning
+                    .shouldContain("-Djava.security.manager=SecurityManagerWarnings$MySM will have no effect")
+                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+
+            // Default SecurityManager does not allow setSecurityManager
+
             run("")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager")
+                    .shouldContain("-Djava.security.manager will have no effect")
                     .shouldContain("AccessControlException");
+
             run("default")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager")
+                    .shouldContain("-Djava.security.manager=default will have no effect")
                     .shouldContain("AccessControlException");
         } else {
             System.out.println("SM is enabled: " + (System.getSecurityManager() != null));
@@ -79,7 +83,6 @@ public class SecurityManagerWarnings {
             System.setErr(new PrintStream(new ByteArrayOutputStream()));
             Exception ex = null;
             try {
-                System.setSecurityManager(new MySM());
                 System.setSecurityManager(new MySM());
             } catch (Exception e) {
                 ex = e;

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -41,39 +41,39 @@ public class SecurityManagerWarnings {
             run(null)
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
-                    .shouldNotContain("-Djava.security.manager")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+                    .shouldNotContain("A command line option has enabled the Security Manager")
+                    .shouldContain("System::setSecurityManager will be removed in a future release");
 
             run("allow")
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
-                    .shouldNotContain("-Djava.security.manager")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+                    .shouldNotContain("A command line option has enabled the Security Manager")
+                    .shouldContain("System::setSecurityManager will be removed in a future release");
 
             run("disallow")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: false")
-                    .shouldNotContain("-Djava.security.manager")
+                    .shouldNotContain("A command line option has enabled the Security Manager")
                     .shouldContain("UnsupportedOperationException");
 
             run("SecurityManagerWarnings$MySM")
                     .shouldHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager=SecurityManagerWarnings$MySM will have no effect")
-                    .shouldContain("java.lang.System::setSecurityManager will be removed in a future release");
+                    .shouldContain("A command line option has enabled the Security Manager")
+                    .shouldContain("System::setSecurityManager will be removed in a future release");
 
             // Default SecurityManager does not allow setSecurityManager
 
             run("")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager will have no effect")
+                    .shouldContain("A command line option has enabled the Security Manager")
                     .shouldContain("AccessControlException");
 
             run("default")
                     .shouldNotHaveExitValue(0)
                     .shouldContain("SM is enabled: true")
-                    .shouldContain("-Djava.security.manager=default will have no effect")
+                    .shouldContain("A command line option has enabled the Security Manager")
                     .shouldContain("AccessControlException");
         } else {
             System.out.println("SM is enabled: " + (System.getSecurityManager() != null));

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266459
+ * @bug 8266459 8268349
  * @summary check various warnings
  * @library /test/lib
  */

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -28,90 +28,111 @@
  * @library /test/lib
  */
 
+import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.JarUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
-import java.security.Permission;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class SecurityManagerWarnings {
+
     public static void main(String args[]) throws Exception {
         if (args.length == 0) {
-            run(null)
-                    .shouldHaveExitValue(0)
-                    .shouldContain("SM is enabled: false")
-                    .shouldNotContain("A command line option has enabled the Security Manager")
-                    .shouldContain("System::setSecurityManager will be removed in a future release");
+            Files.writeString(Path.of("policy"), """
+                    grant {
+                        permission java.lang.RuntimePermission "setIO";
+                        permission java.lang.RuntimePermission "createSecurityManager";
+                        permission java.lang.RuntimePermission "setSecurityManager";
+                    };
+                    """);
 
-            run("allow")
-                    .shouldHaveExitValue(0)
-                    .shouldContain("SM is enabled: false")
-                    .shouldNotContain("A command line option has enabled the Security Manager")
-                    .shouldContain("System::setSecurityManager will be removed in a future release");
+            String testClasses = System.getProperty("test.classes");
 
-            run("disallow")
-                    .shouldNotHaveExitValue(0)
-                    .shouldContain("SM is enabled: false")
-                    .shouldNotContain("A command line option has enabled the Security Manager")
-                    .shouldContain("UnsupportedOperationException");
+            allowTest(null, testClasses);
+            allowTest("allow", testClasses);
+            disallowTest("disallow", testClasses);
+            enableTest("", testClasses);
+            enableTest("default", testClasses);
+            enableTest("java.lang.SecurityManager", testClasses);
 
-            run("SecurityManagerWarnings$MySM")
-                    .shouldHaveExitValue(0)
-                    .shouldContain("SM is enabled: true")
-                    .shouldContain("A command line option has enabled the Security Manager")
-                    .shouldContain("System::setSecurityManager will be removed in a future release");
+            JarUtils.createJarFile(Path.of("a.jar"),
+                    Path.of(testClasses),
+                    Path.of("SecurityManagerWarnings.class"));
 
-            // Default SecurityManager does not allow setSecurityManager
-
-            run("")
-                    .shouldNotHaveExitValue(0)
-                    .shouldContain("SM is enabled: true")
-                    .shouldContain("A command line option has enabled the Security Manager")
-                    .shouldContain("AccessControlException");
-
-            run("default")
-                    .shouldNotHaveExitValue(0)
-                    .shouldContain("SM is enabled: true")
-                    .shouldContain("A command line option has enabled the Security Manager")
-                    .shouldContain("AccessControlException");
+            allowTest(null, "a.jar");
         } else {
             System.out.println("SM is enabled: " + (System.getSecurityManager() != null));
             PrintStream oldErr = System.err;
-            // Modify System.err, make sure warnings are printed to the
-            // original System.err and will not be swallowed.
+            // Modify System.err, thus make sure warnings are always printed
+            // to the original System.err and will not be swallowed.
             System.setErr(new PrintStream(new ByteArrayOutputStream()));
-            Exception ex = null;
             try {
-                System.setSecurityManager(new MySM());
+                System.setSecurityManager(new SecurityManager());
             } catch (Exception e) {
-                ex = e;
-            } finally {
-                System.setErr(oldErr);
-            }
-            // Revert System.err to make sure the exception is
-            // printed to the original System.err.
-            if (ex != null) {
-                throw ex;
+                // Exception messages must show in original stderr
+                e.printStackTrace(oldErr);
+                throw e;
             }
         }
     }
 
-    static OutputAnalyzer run(String prop) throws Exception {
+    // When SM is allowed, no startup warning, has setSM warning
+    static void allowTest(String prop, String cp) throws Exception {
+        checkInstallMessage(run(prop, cp), cp)
+                .shouldHaveExitValue(0)
+                .stdoutShouldContain("SM is enabled: false")
+                .shouldNotContain("A command line option");
+    }
+
+    // When SM is disallowed, no startup warning, setSM fails
+    static void disallowTest(String prop, String cp) throws Exception {
+        run(prop, cp)
+                .shouldNotHaveExitValue(0)
+                .stdoutShouldContain("SM is enabled: false")
+                .shouldNotContain("A command line option")
+                .shouldNotContain("A terminally deprecated method")
+                .stderrShouldContain("UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release");
+    }
+
+    // When SM is allowed, has startup warning, has setSM warning
+    static void enableTest(String prop, String cp) throws Exception {
+        checkInstallMessage(run(prop, cp), cp)
+                .shouldHaveExitValue(0)
+                .stdoutShouldContain("SM is enabled: true")
+                .stderrShouldContain("WARNING: A command line option has enabled the Security Manager")
+                .stderrShouldContain("WARNING: The Security Manager is deprecated and will be removed in a future release");
+    }
+
+    // Check the setSM warning
+    static OutputAnalyzer checkInstallMessage(OutputAnalyzer oa, String cp) {
+        String uri = new File(cp).toURI().toString();
+        return oa
+                .stderrShouldContain("WARNING: A terminally deprecated method in java.lang.System has been called")
+                .stderrShouldContain("WARNING: System::setSecurityManager has been called by SecurityManagerWarnings (" + uri + ")")
+                .stderrShouldContain("WARNING: Please consider reporting this to the maintainers of SecurityManagerWarnings")
+                .stderrShouldContain("WARNING: System::setSecurityManager will be removed in a future release");
+    }
+
+    static OutputAnalyzer run(String prop, String cp) throws Exception {
+        ProcessBuilder pb;
         if (prop == null) {
-            return ProcessTools.executeTestJvm(
+            pb = new ProcessBuilder(
+                    JDKToolFinder.getJDKTool("java"),
+                    "-cp", cp,
                     "SecurityManagerWarnings", "run");
         } else {
-            return ProcessTools.executeTestJvm(
+            pb = new ProcessBuilder(
+                    JDKToolFinder.getJDKTool("java"),
+                    "-cp", cp,
                     "-Djava.security.manager=" + prop,
+                    "-Djava.security.policy=policy",
                     "SecurityManagerWarnings", "run");
         }
-    }
-
-    // This SecurityManager allows everything!
-    public static class MySM extends SecurityManager {
-        @Override
-        public void checkPermission(Permission perm) {
-        }
+        return ProcessTools.executeProcess(pb);
     }
 }

--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -147,9 +147,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djdk.internal.lambda.dumpProxyClasses=notExist",
                                "com.example.TestLambda");
         assertEquals(tr.testOutput.stream()
-                                  .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                   .filter(s -> s.startsWith("WARNING"))
-                                  .peek(s -> assertTrue(s.contains("does not exist")))
+                                  .filter(s -> s.contains("does not exist"))
                                   .count(),
                      1, "only show error once");
         tr.assertZero("Should still return 0");
@@ -164,9 +163,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djdk.internal.lambda.dumpProxyClasses=file",
                                "com.example.TestLambda");
         assertEquals(tr.testOutput.stream()
-                                  .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                   .filter(s -> s.startsWith("WARNING"))
-                                  .peek(s -> assertTrue(s.contains("not a directory")))
+                                  .filter(s -> s.contains("not a directory"))
                                   .count(),
                      1, "only show error once");
         tr.assertZero("Should still return 0");
@@ -224,9 +222,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                    "-Djdk.internal.lambda.dumpProxyClasses=readOnly",
                                    "com.example.TestLambda");
             assertEquals(tr.testOutput.stream()
-                                      .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                       .filter(s -> s.startsWith("WARNING"))
-                                      .peek(s -> assertTrue(s.contains("not writable")))
+                                      .filter(s -> s.contains("not writable"))
                                       .count(),
                          1, "only show error once");
             tr.assertZero("Should still return 0");

--- a/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
+++ b/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
@@ -86,10 +86,14 @@ public class Basic {
     static final String SECURITY_MANAGER_DEPRECATED
             = "WARNING: The Security Manager is deprecated and will be removed in a future release."
                     + System.getProperty("line.separator");
+
+    private static String withoutWarning(String in) {
+        return in.lines().filter(s -> !s.startsWith("WARNING:")).collect(Collectors.joining());
+    }
+
     static final Consumer<Result> KNOWN = r -> {
-        if (r.exitValue != 0 ||
-                (!r.output.isEmpty() && !r.output.equals(SECURITY_MANAGER_DEPRECATED)))
-            throw new RuntimeException(r.output);
+        if (r.exitValue != 0 || !withoutWarning(r.output).isEmpty())
+            throw new RuntimeException("[" + r.output + "]");
     };
     static final Consumer<Result> UNKNOWN = r -> {
         if (r.exitValue == 0 ||

--- a/test/jdk/java/security/ProtectionDomain/RecursionDebug.java
+++ b/test/jdk/java/security/ProtectionDomain/RecursionDebug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4947618
+ * @bug 4947618 8268349
  * @summary Recursion problem in security manager and policy code
  *
  * @run main/othervm/policy=Recursion.policy -Djava.security.debug=domain RecursionDebug
@@ -87,7 +87,5 @@ public class RecursionDebug {
             throw new Exception
                 ("Test with custom non-bootclass SecurityManager failed");
         }
-
-        System.setSecurityManager(null);
     }
 }


### PR DESCRIPTION
More loudly and precise warning messages when a security manager is either enabled at startup or installed at runtime.

This is new PR for the `openjdk/jdk17` repo copied from https://github.com/openjdk/jdk/pull/4400. A new commit is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268349](https://bugs.openjdk.java.net/browse/JDK-8268349): Provide clear run-time warnings about Security Manager deprecation ⚠️ Issue is not open.


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to cb732f99ce13875c3c9aff3c8dacf1298dbec19b
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 2d5b1ba53c6fb5db8346896b3fa3a23318bda5c3
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 2d5b1ba53c6fb5db8346896b3fa3a23318bda5c3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/13.diff">https://git.openjdk.java.net/jdk17/pull/13.diff</a>

</details>
