### PR TITLE
8268580: runtime/memory/LargePages/TestLargePagesFlags.java should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestLargePagesFlags
+ * @run driver TestLargePagesFlags
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that updates `TestLargePagesFlags.java` test to use `driver` mode?

testing: `runtime/memory/LargePages/`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268580](https://bugs.openjdk.java.net/browse/JDK-8268580): runtime/memory/LargePages/TestLargePagesFlags.java should be run in driver mode


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/15.diff">https://git.openjdk.java.net/jdk17/pull/15.diff</a>

</details>
