### PR TITLE
8268591: a few runtime/jni tests don't need `/othervm`

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
+++ b/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
@@ -32,7 +32,7 @@ import jdk.test.lib.process.ProcessTools;
  *          atexit handler fails as expected without crashing.
  *
  * @library /test/lib
- * @run main/othervm/native TestAtExit
+ * @run main/native TestAtExit
  */
 
 public class TestAtExit {

--- a/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
+++ b/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedEnsureLocalCapacity.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedEnsureLocalCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedEnsureLocalCapacity.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedEnsureLocalCapacity.java
@@ -25,8 +25,9 @@
  * @bug 8193222
  * @summary Check EnsureLocalCapacity doesn't shrink unexpectedly
  * @library /test/lib
- * @run main/othervm/native TestCheckedEnsureLocalCapacity launch
+ * @run main/native TestCheckedEnsureLocalCapacity launch
  */
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -65,6 +66,7 @@ public class TestCheckedEnsureLocalCapacity {
 
         // No warning
         ProcessTools.executeTestJvm("-Xcheck:jni",
+                                    "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
                                     "TestCheckedEnsureLocalCapacity",
                                     Integer.toString(testArgs[0][0]),
                                     Integer.toString(testArgs[0][1])).
@@ -77,6 +79,7 @@ public class TestCheckedEnsureLocalCapacity {
 
         // Warning
         ProcessTools.executeTestJvm("-Xcheck:jni",
+                                    "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
                                     "TestCheckedEnsureLocalCapacity",
                                     Integer.toString(testArgs[1][0]),
                                     Integer.toString(testArgs[1][1])).

--- a/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
+++ b/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -30,7 +32,7 @@ import jdk.test.lib.process.ProcessTools;
  *          generates a warning when not done from a boot class
  *
  * @library /test/lib
- * @run main/othervm/native TestRegisterNativesWarning
+ * @run main/native TestRegisterNativesWarning
  */
 
 public class TestRegisterNativesWarning {
@@ -61,15 +63,17 @@ public class TestRegisterNativesWarning {
     public static void main(String[] args) throws Exception {
         String warning = "Re-registering of platform native method: java.lang.Thread.yield()V from code in a different classloader";
 
-        OutputAnalyzer output = ProcessTools.executeTestJvm(Tester.class.getName());
+        String cp = Utils.TEST_CLASS_PATH;
+        String libp = Utils.TEST_NATIVE_PATH;
+        OutputAnalyzer output = ProcessTools.executeTestJvm("-Djava.library.path=" + libp,
+                                                            Tester.class.getName());
         output.shouldContain(warning);
         output.shouldHaveExitValue(0);
         output.reportDiagnosticSummary();
 
         // If we run everything from the "boot" loader there should be no warning
-        String cp = System.getProperty("test.class.path");
-        String libp = System.getProperty("java.library.path");
-        output = ProcessTools.executeTestJvm("-Xbootclasspath/a:" + cp,
+        output = ProcessTools.executeTestJvm("-Djava.library.path=" + libp,
+                                             "-Xbootclasspath/a:" + cp,
                                              "-Dsun.boot.library.path=" + libp,
                                              Tester.class.getName());
         output.shouldNotContain(warning);

--- a/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
+++ b/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that removes `/othervm` from 3 `runtime/jni` tests?
from JBS:
> `runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java`, `checked/TestCheckedEnsureLocalCapacity.java`, and `atExit/TestAtExit.java` use `main/othervm` whereas in fact, they don't need `othervm`, and if we had CODETOOLS-7902658 implemented, they would have used `driver` mode. this RFE is to remove `/othervm`, so we at least won't waste time on creating a fresh JVM.

the patch explicitly sets `-Djava.library.path=` for the child processes so they are able to locate native libraries.

testing: `runtime/jni` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268591](https://bugs.openjdk.java.net/browse/JDK-8268591): a few runtime/jni tests don't need `/othervm`


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/18.diff">https://git.openjdk.java.net/jdk17/pull/18.diff</a>

</details>
