### PR TITLE
8268594: runtime/handshake tests don't need WhiteBox after AOT removal

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
@@ -36,20 +36,11 @@ import sun.hotspot.WhiteBox;
  * @library /testlibrary /test/lib
  * @build HandshakeTimeoutTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI HandshakeTimeoutTest
+ * @run main HandshakeTimeoutTest
  */
 
 public class HandshakeTimeoutTest {
     public static void main(String[] args) throws Exception {
-        WhiteBox wb = WhiteBox.getWhiteBox();
-        Boolean useJVMCICompiler = wb.getBooleanVMFlag("UseJVMCICompiler");
-        String useJVMCICompilerStr;
-        if (useJVMCICompiler != null) {
-            useJVMCICompilerStr = useJVMCICompiler ?  "-XX:+UseJVMCICompiler" : "-XX:-UseJVMCICompiler";
-        } else {
-            // pass something innocuous
-            useJVMCICompilerStr = "-XX:+UnlockExperimentalVMOptions";
-        }
         ProcessBuilder pb =
             ProcessTools.createTestJvm(
                     "-Xbootclasspath/a:.",
@@ -63,7 +54,6 @@ public class HandshakeTimeoutTest {
                     "-XX:+UnlockExperimentalVMOptions",
                     "-XX:HandshakeTimeout=50",
                     "-XX:-CreateCoredumpOnCrash",
-                    useJVMCICompilerStr,
                     "HandshakeTimeoutTest$Test");
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);

--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTransitionTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTransitionTest.java
@@ -26,31 +26,19 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
-import sun.hotspot.WhiteBox;
-
 /*
  * @test HandshakeTransitionTest
  * @summary This does a sanity test of the poll in the native wrapper.
  * @requires vm.debug
  * @library /testlibrary /test/lib
  * @build HandshakeTransitionTest
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm/native -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI HandshakeTransitionTest
+ * @run main/native HandshakeTransitionTest
  */
 
 public class HandshakeTransitionTest {
     public static native void someTime(int ms);
 
     public static void main(String[] args) throws Exception {
-        WhiteBox wb = WhiteBox.getWhiteBox();
-        Boolean useJVMCICompiler = wb.getBooleanVMFlag("UseJVMCICompiler");
-        String useJVMCICompilerStr;
-        if (useJVMCICompiler != null) {
-            useJVMCICompilerStr = useJVMCICompiler ?  "-XX:+UseJVMCICompiler" : "-XX:-UseJVMCICompiler";
-        } else {
-            // pass something innocuous
-            useJVMCICompilerStr = "-XX:+UnlockExperimentalVMOptions";
-        }
         ProcessBuilder pb =
             ProcessTools.createTestJvm(
                     "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
@@ -61,8 +49,6 @@ public class HandshakeTransitionTest {
                     "-XX:ParallelGCThreads=1",
                     "-XX:ConcGCThreads=1",
                     "-XX:CICompilerCount=2",
-                    "-XX:+UnlockExperimentalVMOptions",
-                    useJVMCICompilerStr,
                     "HandshakeTransitionTest$Test");
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);


### PR DESCRIPTION
Hi all,

could you please review this small test-only patch?
from JBS:
> `runtime/handshake/HandshakeTransitionTest.java` and `HandshakeTimeoutTest.java` use WhiteBox to check the value of `UseJVMCICompiler` as a workaround for AOT not supporting local handshakes (see [JDK-8191437](https://bugs.openjdk.java.net/browse/JDK-8191437)). 
>
> this isn't needed anymore and can be removed.

testing: `runtime/handshake` tests on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268594](https://bugs.openjdk.java.net/browse/JDK-8268594): runtime/handshake tests don't need WhiteBox after AOT removal


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/19.diff">https://git.openjdk.java.net/jdk17/pull/19.diff</a>

</details>
