### PR TITLE
8268596: mark hotspot runtime/verifier tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/verifier/TraceClassRes.java
+++ b/test/hotspot/jtreg/runtime/verifier/TraceClassRes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/verifier/TraceClassRes.java
+++ b/test/hotspot/jtreg/runtime/verifier/TraceClassRes.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8076318
  * @summary split verifier needs to add class resolution tracing
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TraceClassRes


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `verifier/TraceClassRes.java` test as it ignores all external flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268596](https://bugs.openjdk.java.net/browse/JDK-8268596): mark hotspot runtime/verifier tests which ignore external VM flags


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/20.diff">https://git.openjdk.java.net/jdk17/pull/20.diff</a>

</details>
