### PR TITLE
8268597: mark hotspot runtime/symboltable tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/symboltable/ShortLivedSymbolCleanup.java
+++ b/test/hotspot/jtreg/runtime/symboltable/ShortLivedSymbolCleanup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/symboltable/ShortLivedSymbolCleanup.java
+++ b/test/hotspot/jtreg/runtime/symboltable/ShortLivedSymbolCleanup.java
@@ -26,6 +26,7 @@
  * @bug 8195100
  * @summary a short lived Symbol should be cleaned up
  * @requires vm.debug
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `symboltable/ShortLivedSymbolCleanup.java` test as it ignores all external flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268597](https://bugs.openjdk.java.net/browse/JDK-8268597): mark hotspot runtime/symboltable tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/21.diff">https://git.openjdk.java.net/jdk17/pull/21.diff</a>

</details>
