### PR TITLE
8268599: mark hotspot runtime/sealedClasses tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/sealedClasses/RedefinePermittedSubclass.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/RedefinePermittedSubclass.java
@@ -30,6 +30,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @compile RedefinePermittedSubclass.java
  * @run driver RedefinePermittedSubclass buildagent
  * @run driver/timeout=6000 RedefinePermittedSubclass runtest

--- a/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  * @requires vm.jvmti
+ * @requires vm.flagless
  * @compile RedefineSealedClass.java
  * @run driver RedefineSealedClass buildagent
  * @run driver/timeout=6000 RedefineSealedClass runtest


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `runtime/sealedClasses` tests which ignore all external flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268599](https://bugs.openjdk.java.net/browse/JDK-8268599): mark hotspot runtime/sealedClasses tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/23.diff">https://git.openjdk.java.net/jdk17/pull/23.diff</a>

</details>
