### PR TITLE
8268602: a couple runtime/os tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
@@ -88,6 +88,7 @@ public class AvailableProcessors {
                                    ProcessTools.getCommandLine(pb));
                 OutputAnalyzer output = ProcessTools.executeProcess(pb);
                 output.shouldContain(SUCCESS_STRING);
+                output.shouldHaveExitValue(0);
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
@@ -87,8 +87,8 @@ public class AvailableProcessors {
                 System.out.println("Final command line: " +
                                    ProcessTools.getCommandLine(pb));
                 OutputAnalyzer output = ProcessTools.executeProcess(pb);
-                output.shouldContain(SUCCESS_STRING);
                 output.shouldHaveExitValue(0);
+                output.shouldContain(SUCCESS_STRING);
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
+++ b/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
@@ -47,7 +47,7 @@ public class TestUseCpuAllocPath {
                                                   "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain(SUCCESS_STRING);
         output.shouldHaveExitValue(0);
+        output.shouldContain(SUCCESS_STRING);
     }
 }

--- a/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
+++ b/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
@@ -48,5 +48,6 @@ public class TestUseCpuAllocPath {
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain(SUCCESS_STRING);
+        output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
+++ b/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

could you please review this trivial and test-only patch that adds checks of exit code to two `runtime/os` tests?
from JBS:
> `runtime/os/TestUseCpuAllocPath.java` and `AvailableProcessors.java` spawn new JVMs but don't check their exit code which might lead to both type-I and type-II errors

testing: ``runtime/os` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268602](https://bugs.openjdk.java.net/browse/JDK-8268602): a couple runtime/os tests don't check exit code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to abaabc29d955ff03c4f472f658b0faff8e352fff


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/25.diff">https://git.openjdk.java.net/jdk17/pull/25.diff</a>

</details>
