### PR TITLE
8268333: javac crashes when pattern matching switch contains default case which is not last

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -431,6 +431,7 @@ public class TransPatterns extends TreeTranslator {
 
             int i = 0;
             boolean previousCompletesNormally = false;
+            boolean hasDefault = false;
 
             for (var c : cases) {
                 List<JCCaseLabel> clearedPatterns = c.labels;
@@ -477,7 +478,9 @@ public class TransPatterns extends TreeTranslator {
                     for (var p : c.labels) {
                         if (p.hasTag(Tag.DEFAULTCASELABEL)) {
                             translatedLabels.add(p);
-                        } else if (hasTotalPattern && c == lastCase && p.isPattern()) {
+                            hasDefault = true;
+                        } else if (hasTotalPattern && !hasDefault &&
+                                   c == lastCase && p.isPattern()) {
                             //If the switch has total pattern, the last case will contain it.
                             //Convert the total pattern to default:
                             translatedLabels.add(make.DefaultCaseLabel());

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8268333
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -46,6 +46,8 @@ public class Switches {
         assertTrue(testNullSwitch(""));
         runArrayTypeTest(this::testArrayTypeStatement);
         runArrayTypeTest(this::testArrayTypeExpression);
+        runDefaultTest(this::testDefaultDoesNotDominateStatement);
+        runDefaultTest(this::testDefaultDoesNotDominateExpression);
         runEnumTest(this::testEnumExpression1);
         runEnumTest(this::testEnumExpression2);
         runEnumTest(this::testEnumWithGuards1);
@@ -79,6 +81,13 @@ public class Switches {
         assertEquals("str6", mapper.apply("string"));
         assertEquals("i1", mapper.apply(1));
         assertEquals("", mapper.apply(1.0));
+    }
+
+    void runDefaultTest(Function<Object, String> mapper) {
+        assertEquals("default", mapper.apply(new int[0]));
+        assertEquals("str6", mapper.apply("string"));
+        assertEquals("default", mapper.apply(1));
+        assertEquals("default", mapper.apply(1.0));
     }
 
     void runEnumTest(Function<E, String> mapper) {
@@ -169,6 +178,22 @@ public class Switches {
             case int[] arr -> "arr" + arr.length;
             case String str -> "str" + str.length();
             default -> "";
+        };
+    }
+
+    String testDefaultDoesNotDominateStatement(Object o) {
+        String res;
+        switch (o) {
+            default -> res = "default";
+            case String str -> res = "str" + str.length();
+        }
+        return res;
+    }
+
+    String testDefaultDoesNotDominateExpression(Object o) {
+        return switch (o) {
+            case default -> "default";
+            case String str -> "str" + str.length();
         };
     }
 


### PR DESCRIPTION
[this is a copy of a PR from openjdk/jdk:
https://github.com/openjdk/jdk/pull/4397
]

The pattern matching switch desugaring should recognize cases where there is default case followed by a type pattern case, and not replace the type pattern with another default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268333](https://bugs.openjdk.java.net/browse/JDK-8268333): javac crashes when pattern matching switch contains default case which is not last


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/26.diff">https://git.openjdk.java.net/jdk17/pull/26.diff</a>

</details>
