### PR TITLE
8267271: Fix gc/arguments/TestNewRatioFlag.java expectedNewSize calculation

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
@@ -122,11 +122,12 @@ public class TestNewRatioFlag {
         public static void verifyDefNewNewRatio(int expectedRatio) {
             long initEden = HeapRegionUsageTool.getEdenUsage().getInit();
             long initSurv = HeapRegionUsageTool.getSurvivorUsage().getInit();
-            long initOld = HeapRegionUsageTool.getOldUsage().getInit();
+            long initHeap = HeapRegionUsageTool.getHeapUsage().getInit();
 
             long newSize = initEden + 2 * initSurv;
 
-            long expectedNewSize = HeapRegionUsageTool.alignDown(initOld / expectedRatio,
+            // See GenArguments::scale_by_NewRatio_aligned for calculation in the JVM.
+            long expectedNewSize = HeapRegionUsageTool.alignDown(initHeap / (expectedRatio + 1),
                     wb.getHeapSpaceAlignment());
 
             if (expectedNewSize != newSize) {
@@ -143,11 +144,12 @@ public class TestNewRatioFlag {
         public static void verifyPSNewRatio(int expectedRatio) {
             long initEden = HeapRegionUsageTool.getEdenUsage().getInit();
             long initSurv = HeapRegionUsageTool.getSurvivorUsage().getInit();
-            long initOld = HeapRegionUsageTool.getOldUsage().getInit();
+            long initHeap = HeapRegionUsageTool.getHeapUsage().getInit();
 
             long newSize = initEden + 2 * initSurv;
 
-            long alignedDownNewSize = HeapRegionUsageTool.alignDown(initOld / expectedRatio,
+            // See GenArguments::scale_by_NewRatio_aligned for calculation in the JVM.
+            long alignedDownNewSize = HeapRegionUsageTool.alignDown(initHeap / (expectedRatio + 1),
                     wb.getHeapSpaceAlignment());
             long expectedNewSize = HeapRegionUsageTool.alignUp(alignedDownNewSize,
                     wb.psVirtualSpaceAlignment());


### PR DESCRIPTION
Please review this test-fix to avoid failures on certain platforms.

**Summary**
Fixes an incorrect calculation in the test when trying to predict the new size given the `NewRatio`. The fix is not strictly bound to different platforms but to the resulting heap-size the test is run with. Both with Serial and Parallel the test fails if run on a platform using a heap alignment that forces the heap to be 104 MB instead of the specified 100 MB. It is a bit unclear why the test even passes with 100MB, since the calculation done in the test doesn't match the calculation done in the JVM. 

**Testing**
Manual testing to verify the fix actually fixes the issue and works with multiple page sizes. Mach5 testing on affected platforms to verify the fix is good there as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267271](https://bugs.openjdk.java.net/browse/JDK-8267271): Fix gc/arguments/TestNewRatioFlag.java expectedNewSize calculation


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/28.diff">https://git.openjdk.java.net/jdk17/pull/28.diff</a>

</details>
