### PR TITLE
8268433: serviceability/dcmd/framework/VMVersionTest.java  fails with Unable to send object throw not established PipeIO Listener  Thread connection

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
@@ -77,7 +77,11 @@ public class TestProcessLauncher {
 
     public void quit() {
         if (pipe != null) {
-            pipe.println("quit");
+            if (pipe.isConnected()) {
+                pipe.println("quit");
+            } else {
+                System.out.println("WARNING: IOPipe is not connected");
+            }
         }
     }
 


### PR DESCRIPTION
The fix adds check that IOPipe is connected before sending "quit" command

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268433](https://bugs.openjdk.java.net/browse/JDK-8268433): serviceability/dcmd/framework/VMVersionTest.java fails with Unable to send object throw not established PipeIO Listener Thread connection


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/32.diff">https://git.openjdk.java.net/jdk17/pull/32.diff</a>

</details>
