### PR TITLE
8268621: SunJCE provider may throw unexpected NPE for un-initialized AES KW/KWP Ciphers

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESKeyWrap.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESKeyWrap.java
@@ -41,7 +41,7 @@ import static com.sun.crypto.provider.KWUtil.*;
 class AESKeyWrap extends FeedbackCipher {
 
     // default integrity check value (icv) if iv is not supplied
-    private static final byte[] ICV1 = { // SEMI_BLKSIZE long
+    static final byte[] ICV1 = { // SEMI_BLKSIZE long
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6,
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6
     };

--- a/src/java.base/share/classes/com/sun/crypto/provider/AESKeyWrapPadded.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESKeyWrapPadded.java
@@ -42,7 +42,7 @@ import static com.sun.crypto.provider.KWUtil.*;
 class AESKeyWrapPadded extends FeedbackCipher {
 
     // default integrity check value (icv) if iv is not supplied
-    private static final byte[] ICV2 = { // SEMI_BLKSIZE/2 long
+    static final byte[] ICV2 = { // SEMI_BLKSIZE/2 long
         (byte) 0xA6, (byte) 0x59, (byte) 0x59, (byte) 0xA6,
     };
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
@@ -161,6 +161,7 @@ abstract class KeyWrapCipher extends CipherSpi {
     }
 
     // internal cipher object which does the real work.
+    // AESKeyWrap for KW, AESKeyWrapPadded for KWP
     private final FeedbackCipher cipher;
 
     // internal padding object; null if NoPadding
@@ -279,13 +280,15 @@ abstract class KeyWrapCipher extends CipherSpi {
     }
 
     /**
-     * Returns the initialization vector (IV).
+     * Returns the initialization vector (IV) in a new buffer.
      *
-     * @return the user-specified iv or null if default iv is used.
+     * @return the user-specified iv, or null if the underlying algorithm does
+     * not use an IV, or if the IV has not yet been set.
      */
     @Override
     protected byte[] engineGetIV() {
-        return cipher.getIV().clone();
+        byte[] iv = cipher.getIV();
+        return (iv == null? null : iv.clone());
     }
 
     // actual impl for various engineInit(...) methods
@@ -623,13 +626,18 @@ abstract class KeyWrapCipher extends CipherSpi {
     /**
      * Returns the parameters used with this cipher.
      *
-     * @return AlgorithmParameters object containing IV.
+     * @return AlgorithmParameters object containing IV, or null if this cipher
+     * does not use any parameters.
      */
     @Override
     protected AlgorithmParameters engineGetParameters() {
         AlgorithmParameters params = null;
 
         byte[] iv = cipher.getIV();
+        if (iv == null) {
+            iv = (cipher instanceof AESKeyWrap?
+                    AESKeyWrap.ICV1 : AESKeyWrapPadded.ICV2);
+        }
         try {
             params = AlgorithmParameters.getInstance("AES");
             params.init(new IvParameterSpec(iv));


### PR DESCRIPTION
Could someone help review this straightforward fix? The current impl for AES KW and KWP cipher should check for possible null iv value in its CipherSpi.engineGetIV() and CipherSpi.engineGetParameters() impls. Updated the regression test to cover this scenario as well as some other minor updates.

Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268621](https://bugs.openjdk.java.net/browse/JDK-8268621): SunJCE provider may throw unexpected NPE for un-initialized AES KW/KWP Ciphers


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/34.diff">https://git.openjdk.java.net/jdk17/pull/34.diff</a>

</details>
