### PR TITLE
8267397: AlgorithmId's OID cache is never refreshed

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -26,6 +26,7 @@
 package sun.security.jca;
 
 import java.security.Provider;
+import sun.security.x509.AlgorithmId;
 
 /**
  * Collection of methods to get and set provider list. Also includes
@@ -150,7 +151,17 @@ public class Providers {
         } else {
             changeThreadProviderList(newList);
         }
+        clearCachedValues();
+    }
+
+    /**
+     * Clears the cached provider-list-specific values. These values need to
+     * be re-generated whenever provider list is changed. The logic for
+     * generating them is in the respective classes.
+     */
+    private static void clearCachedValues() {
         JCAUtil.clearDefSecureRandom();
+        AlgorithmId.clearAliasOidsTable();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -536,6 +536,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
     // oid string cache index'ed by algorithm name and oid strings
     private static volatile Map<String,String> aliasOidsTable;
 
+    // called by sun.security.jca.Providers whenever provider list is changed
+    public static void clearAliasOidsTable() {
+        aliasOidsTable = null;
+    }
+
     // returns the aliasOidsTable, lazily initializing it on first access.
     private static Map<String,String> aliasOidsTable() {
         // Double checked locking; safe because aliasOidsTable is volatile


### PR DESCRIPTION
Could someone help review this small fix? This clears the static aliasOidsTable field in AlgorithmId class when provider list is changed. Enhanced existing regression test to cover the provider removal scenario.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267397](https://bugs.openjdk.java.net/browse/JDK-8267397): AlgorithmId's OID cache is never refreshed


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/36.diff">https://git.openjdk.java.net/jdk17/pull/36.diff</a>

</details>
