### PR TITLE
8267579: Thread::cooked_allocated_bytes() hits assert(left >= right) failed: avoid underflow

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -31,6 +31,7 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/perfData.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"
@@ -472,4 +473,12 @@ void ThreadLocalAllocStats::publish() {
 size_t ThreadLocalAllocBuffer::end_reserve() {
   size_t reserve_size = Universe::heap()->tlab_alloc_reserve();
   return MAX2(reserve_size, (size_t)_reserve_for_allocation_prefetch);
+}
+
+const HeapWord* ThreadLocalAllocBuffer::start_relaxed() const {
+  return Atomic::load(&_start);
+}
+
+const HeapWord* ThreadLocalAllocBuffer::top_relaxed() const {
+  return Atomic::load(&_top);
 }

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -129,6 +129,10 @@ public:
   size_t refill_waste_limit() const              { return _refill_waste_limit; }
   size_t bytes_since_last_sample_point() const   { return _bytes_since_last_sample_point; }
 
+  // For external inspection.
+  const HeapWord* start_relaxed() const;
+  const HeapWord* top_relaxed() const;
+
   // Allocate size HeapWords. The memory is NOT initialized to zero.
   inline HeapWord* allocate(size_t size);
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267579](https://bugs.openjdk.java.net/browse/JDK-8267579): Thread::cooked_allocated_bytes() hits assert(left >= right) failed: avoid underflow


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/40.diff">https://git.openjdk.java.net/jdk17/pull/40.diff</a>

</details>
