### PR TITLE
8268663: Crash when guards contain boolean expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2392,6 +2392,10 @@ public class Flow {
                 JCCase c = l.head;
                 for (JCCaseLabel pat : c.labels) {
                     scan(pat);
+                    if (inits.isReset()) {
+                        inits.assign(initsWhenTrue);
+                        uninits.assign(uninitsWhenTrue);
+                    }
                 }
                 if (l.head.stats.isEmpty() &&
                     l.tail.nonEmpty() &&

--- a/test/langtools/tools/javac/patterns/Guards.java
+++ b/test/langtools/tools/javac/patterns/Guards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8268663
  * @summary Check guards implementation.
  * @compile --enable-preview -source ${jdk.version} Guards.java
  * @run main/othervm --enable-preview Guards
@@ -43,12 +43,20 @@ public class Guards {
         run(this::testBooleanSwitchExpression);
         assertEquals("a", testPatternInGuard("a"));
         assertEquals(null, testPatternInGuard(1));
+        runIfTrue(this::typeGuardIfTrueIfStatement);
+        runIfTrue(this::typeGuardIfTrueSwitchExpression);
+        runIfTrue(this::typeGuardIfTrueSwitchStatement);
     }
 
     void run(Function<Object, String> convert) {
         assertEquals("zero", convert.apply(0));
         assertEquals("one", convert.apply(1));
         assertEquals("other", convert.apply(-1));
+        assertEquals("any", convert.apply(""));
+    }
+
+    void runIfTrue(Function<Object, String> convert) {
+        assertEquals("true", convert.apply(0));
         assertEquals("any", convert.apply(""));
     }
 
@@ -81,6 +89,31 @@ public class Guards {
             return x;
         } else {
             throw new IllegalStateException("TODO - needed?");
+        }
+    }
+
+    String typeGuardIfTrueSwitchStatement(Object o) {
+        Object o2 = "";
+        switch (o) {
+            case Integer i && i == 0 && i < 1 && o2 instanceof String s: o = s + String.valueOf(i); return "true";
+            case Object x: return "any";
+        }
+    }
+
+    String typeGuardIfTrueSwitchExpression(Object o) {
+        Object o2 = "";
+        return switch (o) {
+            case Integer i && i == 0 && i < 1 && o2 instanceof String s: o = s + String.valueOf(i); yield "true";
+            case Object x: yield "any";
+        };
+    }
+
+    String typeGuardIfTrueIfStatement(Object o) {
+        Object o2 = "";
+        if (o != null && o instanceof (Integer i && i == 0 && i < 1) && (o = i) != null && o2 instanceof String s) {
+            return s != null ? "true" : null;
+        } else {
+            return "any";
         }
     }
 

--- a/test/langtools/tools/javac/patterns/Guards.java
+++ b/test/langtools/tools/javac/patterns/Guards.java
@@ -57,6 +57,7 @@ public class Guards {
 
     void runIfTrue(Function<Object, String> convert) {
         assertEquals("true", convert.apply(0));
+        assertEquals("second", convert.apply(2));
         assertEquals("any", convert.apply(""));
     }
 
@@ -96,6 +97,7 @@ public class Guards {
         Object o2 = "";
         switch (o) {
             case Integer i && i == 0 && i < 1 && o2 instanceof String s: o = s + String.valueOf(i); return "true";
+            case Integer i && i == 0 || i > 1: o = String.valueOf(i); return "second";
             case Object x: return "any";
         }
     }
@@ -104,6 +106,7 @@ public class Guards {
         Object o2 = "";
         return switch (o) {
             case Integer i && i == 0 && i < 1 && o2 instanceof String s: o = s + String.valueOf(i); yield "true";
+            case Integer i && i == 0 || i > 1: o = String.valueOf(i); yield "second";
             case Object x: yield "any";
         };
     }
@@ -112,6 +115,8 @@ public class Guards {
         Object o2 = "";
         if (o != null && o instanceof (Integer i && i == 0 && i < 1) && (o = i) != null && o2 instanceof String s) {
             return s != null ? "true" : null;
+        } else if (o != null && o instanceof (Integer i && i == 0 || i > 1) && (o = i) != null) {
+            return "second";
         } else {
             return "any";
         }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -190,4 +190,16 @@ public class SwitchErrors {
     }
     sealed class SealedNonAbstract permits A {}
     final class A extends SealedNonAbstract {}
+    Object guardWithMatchingStatement(Object o1, Object o2) {
+        switch (o1) {
+            case String s && s.isEmpty() || o2 instanceof Number n: return n;
+            default: return null;
+        }
+    }
+    Object guardWithMatchingExpression(Object o1, Object o2) {
+        return switch (o1) {
+            case String s && s.isEmpty() || o2 instanceof Number n -> n;
+            default -> null;
+        };
+    }
 }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -28,6 +28,8 @@ SwitchErrors.java:166:18: compiler.err.flows.through.from.pattern
 SwitchErrors.java:171:27: compiler.err.flows.through.to.pattern
 SwitchErrors.java:177:18: compiler.err.flows.through.to.pattern
 SwitchErrors.java:183:13: compiler.err.pattern.dominated
+SwitchErrors.java:195:76: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
+SwitchErrors.java:201:71: compiler.err.cant.resolve.location: kindname.variable, n, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
 SwitchErrors.java:32:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:38:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:44:9: compiler.err.not.exhaustive.statement
@@ -41,4 +43,4 @@ SwitchErrors.java:127:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:187:9: compiler.err.not.exhaustive.statement
 - compiler.note.preview.filename: SwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-41 errors
+43 errors


### PR DESCRIPTION
When Flow analyzes boolean expressions, (un-)initialized are split into (un-)initialized when true and when false. When analyzing guarded patterns, we need to handle these split values. As the only way the case's body/statements can be executed is if the case's pattern matches, we need to use the initialized values when true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268663](https://bugs.openjdk.java.net/browse/JDK-8268663): Crash when guards contain boolean expression


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/41.diff">https://git.openjdk.java.net/jdk17/pull/41.diff</a>

</details>
