### PR TITLE
JDK-8268557: Module page uses unstyled table class

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -350,14 +350,12 @@ ul.see-list-long li:not(:last-child):after {
 /*
  * Styles for tables.
  */
-.summary-table {
+.summary-table, .details-table {
     width:100%;
     border-spacing:0;
     border-left:1px solid #EEE;
     border-right:1px solid #EEE;
     border-bottom:1px solid #EEE;
-}
-.summary-table {
     padding:0;
 }
 .caption {
@@ -445,7 +443,7 @@ div.table-tabs > button.table-tab {
         grid-template-columns: minmax(15%, max-content) minmax(15%, auto);
     }
 }
-.summary-table > div {
+.summary-table > div, .details-table > div {
     text-align:left;
     padding: 8px 3px 3px 7px;
 }

--- a/test/langtools/jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java
@@ -120,7 +120,7 @@ public class CheckStylesheetClasses {
                 "modifiers", "permits", "return-type");
 
         // misc: these are defined in HtmlStyle, and used by the doclet
-        removeAll(htmlStyleNames, "col-plain", "details-table", "external-link",
+        removeAll(htmlStyleNames, "col-plain", "external-link",
                 "hierarchy", "index", "package-uses", "packages", "permits-note",
                 "serialized-package-container", "source-container");
 

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -140,7 +140,7 @@ public class TestStylesheet extends JavadocTester {
                         overflow: auto;
                     }""",
                 """
-                    .summary-table > div {
+                    .summary-table > div, .details-table > div {
                         text-align:left;
                         padding: 8px 3px 3px 7px;
                     }""",


### PR DESCRIPTION
This adds CSS rules for the `details-table` class used in the module summary page. The rules are identical to the ones for the `summary-table` class. The screenshot below shows the module summary page with the fixed stylesheet.

<img width="1120" alt="module-summary-fixed" src="https://user-images.githubusercontent.com/15975/121906627-93175600-cd2b-11eb-8955-c4a72f6aa987.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268557](https://bugs.openjdk.java.net/browse/JDK-8268557): Module page uses unstyled table class


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/43.diff">https://git.openjdk.java.net/jdk17/pull/43.diff</a>

</details>
