### PR TITLE
JDK-8265369 [macos-aarch64] java/net/MulticastSocket/Promiscuous.java failed with "SocketException: Cannot allocate memory"

### DIFF
--- a/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
+++ b/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
@@ -2124,7 +2124,7 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
 #ifdef __APPLE__
             if (errno == ENOMEM) {
                 if (setsockopt(fd, IPPROTO_IPV6, (join ? ADD_MEMBERSHIP : DRP_MEMBERSHIP),
-                           (char *) &mname6, sizeof(mname6)) < 0) { 
+                           (char *) &mname6, sizeof(mname6)) < 0) {
                     if (join) {
                         NET_ThrowCurrent(env, "setsockopt " S_ADD_MEMBERSHIP " failed");
                     } else {

--- a/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
+++ b/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
@@ -2012,8 +2012,8 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
                             }
                             return;
                         }
-                } 
-            } else { 
+                }
+            } else {
 #endif
             /*
              * If IP_ADD_MEMBERSHIP returns ENOPROTOOPT on Linux and we've got
@@ -2135,8 +2135,8 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
                             NET_ThrowCurrent(env, "setsockopt " S_DRP_MEMBERSHIP " failed");
                         }
                     }
-                } 
-            } else { 
+                }
+            } else {
 #endif
 
                 if (join) {

--- a/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
+++ b/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
@@ -1837,9 +1837,7 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
     jint fd;
     jint family;
     jint ipv6_join_leave;
-#ifdef __APPLE__
     int res;
-#endif
 
     if (IS_NULL(fdObj)) {
         JNU_ThrowByName(env, JNU_JAVANETPKG "SocketException",
@@ -2108,7 +2106,7 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
 
         /* Join the multicast group */
         res = setsockopt(fd, IPPROTO_IPV6, (join ? ADD_MEMBERSHIP : DRP_MEMBERSHIP),
-                       (char *) &mname6, sizeof (mname6));
+                       (char *) &mname6, sizeof(mname6));
 
 #ifdef __APPLE__
         if (res < 0 && errno == ENOMEM) {
@@ -2118,7 +2116,7 @@ static void mcast_join_leave(JNIEnv *env, jobject this,
 #endif
         if (res < 0) {
             if (join) {
-                    NET_ThrowCurrent(env, "setsockopt " S_ADD_MEMBERSHIP " failed");
+                NET_ThrowCurrent(env, "setsockopt " S_ADD_MEMBERSHIP " failed");
             } else {
                 if (errno == ENOENT) {
                    JNU_ThrowByName(env, JNU_JAVANETPKG "SocketException",

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -606,7 +606,6 @@ java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-java/net/MulticastSocket/Promiscuous.java                       8265369 macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
JDK-8265369 [macos-aarch64] java/net/MulticastSocket/Promiscuous.java failed with "SocketException: Cannot allocate memory"

The test java/net/MulticastSocket/Promiscuous.java has been observed to fail on a regular basis on macosx-aarch.
This is typically under heavy test load on a test machine. Analysis of the problem have
shown that the setsockopt for joining a multicast group will intermittently fail with ENOMEM.

While analysis of test environment shows significant memory usage and some memory pressure, it is
not excessive and as such it is deemed transition or temporary condition, such that a retry of the
setsockopt system call, has been seen to mitigate the issue. This adds to the stability of the
Promiscuous.java test and reduces test failure noise.

The proposed fix is in open/src/java.base/unix/native/libnet/PlainDatagramSocketImpl.c
in the mcast_join_leave function.  That is, if setsockopt to join an mcast group fails, and the errno == ENOMEM, 
then re-invoke the setsockopt system call for joining a mcast group.
The change has been applied as a conditional compilation.
Additionally this change result in the Promiscuous.java test being removed from the
ProblemList.txt.

Please oblige and review the changes for a fix of the issue JDK-8265369

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265369](https://bugs.openjdk.java.net/browse/JDK-8265369): [macos-aarch64] java/net/MulticastSocket/Promiscuous.java failed with "SocketException: Cannot allocate memory"


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/44.diff">https://git.openjdk.java.net/jdk17/pull/44.diff</a>

</details>
