### PR TITLE
8268566: java/foreign/TestResourceScope.java timed out

### DIFF
--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -46,7 +46,7 @@ import java.util.stream.IntStream;
 
 public class TestResourceScope {
 
-    final static int N_THREADS = 10000;
+    final static int N_THREADS = 100;
 
     @Test(dataProvider = "cleaners")
     public void testConfined(Supplier<Cleaner> cleanerSupplier) {
@@ -204,10 +204,6 @@ public class TestResourceScope {
                     // might be already closed - do nothing
                 }
             }).start();
-        }
-
-        while (lockCount.get() == 0) {
-            waitSomeTime(); // make sure some thread gets scheduled
         }
 
         while (true) {


### PR DESCRIPTION
This patch contains another minor tweak to TestResourceScope as we have seen this test timing out at least once (on arm64).

I realized that some of the logic recently introduced in the test could lead to the test waiting forever: for instance, if all threads are executed right away before the main thread gets a chance to do anything, we'd be in a state where the lock count is zero, and no other thread will update it. I've removed the while loop - as that's not essential to make sure that the test works (what we want is to trigger a close operation that is concurrent with respect some acquire/release).

I've also lowered the number of threads - which was using 10K - that was good for stress testing, but it's not a good number in more realistic conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268566](https://bugs.openjdk.java.net/browse/JDK-8268566): java/foreign/TestResourceScope.java timed out


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/45.diff">https://git.openjdk.java.net/jdk17/pull/45.diff</a>

</details>
