### PR TITLE
8268670: yield statements doesn't allow ~ or ! unary operators in expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2668,6 +2668,9 @@ public class JavacParser implements Parser {
                     case PLUSPLUS: case SUBSUB:
                         isYieldStatement = S.token(2).kind != SEMI;
                         break;
+                    case BANG: case TILDE:
+                        isYieldStatement = S.token(1).kind != SEMI;
+                        break;
                     case LPAREN:
                         int lookahead = 2;
                         int balance = 1;

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8206986 8222169 8224031 8240964 8267119
+ * @bug 8206986 8222169 8224031 8240964 8267119 8268670
  * @summary Check expression switch works.
  * @compile/fail/ref=ExpressionSwitch-old.out -source 9 -Xlint:-options -XDrawDiagnostics ExpressionSwitch.java
  * @compile ExpressionSwitch.java
@@ -117,6 +117,26 @@ public class ExpressionSwitch {
             case "h": yield "";
             case "i": yield null;
             default: yield 0;
+        };
+    }
+
+    private int yieldUnaryNumberOperator(String s, int a) {
+        return switch (s) {
+            case "a": yield +a;
+            case "b": yield -a;
+            case "c": yield ~a; // intentionally repeated ~a, test the case clause
+            case "d": yield ++a;
+            case "e": yield --a;
+            case "f": yield a++;
+            case "g": yield a--;
+            default: yield ~a; // intentionally repeated ~a, test the default clause
+        };
+    }
+
+    private boolean yieldUnaryNotOperator(String s, boolean b) {
+        return switch (s) {
+            case "a": yield !b; // intentionally repeated !b, test the case clause
+            default: yield !b; // intentionally repeated !b, test the default clause
         };
     }
 


### PR DESCRIPTION
Hi all,

Currently, the javac can't address the `yield` statement with `~` or `!` unary operators.
Javac will report the unexpected error messages when compiling the following two demos.

```
class Yield {
  public static void main(String... args) {
    int value = switch (1) {
      default -> {
        yield ~1;
      }
    };
  }
}
```

```
class Yield {
  public static void main(String... args) {
    boolean value = switch (1) {
      default -> {
        yield !true;
      }
    };
  }
}
```

This patch fixes it and adds the corresponding tests.
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268670](https://bugs.openjdk.java.net/browse/JDK-8268670): yield statements doesn't allow ~ or ! unary operators in expression


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/46.diff">https://git.openjdk.java.net/jdk17/pull/46.diff</a>

</details>
