### PR TITLE
8268353: Test libsvml.so is and is not present in jdk image

### DIFF
--- a/test/jdk/jdk/incubator/vector/ImageTest.java
+++ b/test/jdk/jdk/incubator/vector/ImageTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Platform;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.spi.ToolProvider;
+
+/**
+ * @test
+ * @summary Tests that the SVML shared library is present in an image only when jdk.incubator.vector is present
+ * @requires os.arch == "x86_64" | os.arch == "amd64"
+ * @requires os.family == "linux" | os.family == "windows"
+ * @modules jdk.incubator.vector jdk.jlink
+ * @library /test/lib
+ * @run testng ImageTest
+ */
+
+public class ImageTest {
+    static final ToolProvider JLINK_TOOL = ToolProvider.findFirst("jlink")
+            .orElseThrow(() ->
+                    new RuntimeException("jlink tool not found")
+            );
+
+    static final String SVML_LIBRARY_NAME = Platform.isWindows()
+            ? "svml.dll"
+            : "libsvml.so";
+
+    static void link(String module, Path output) {
+        int e = JLINK_TOOL.run(System.out, System.err,
+                "--add-modules", module,
+                "--output", output.toString()
+        );
+        if (e != 0) {
+            throw new RuntimeException("Error running jlink");
+        }
+    }
+
+    static void checkSVML(Path image, boolean shouldBepresent) {
+        Path libsvml = Platform.libDir(image).resolve(SVML_LIBRARY_NAME);
+
+        boolean exists = Files.exists(libsvml);
+        if (shouldBepresent) {
+            Assert.assertTrue(exists, libsvml + " should be present");
+        } else {
+            Assert.assertFalse(exists, libsvml + "should be absent");
+        }
+    }
+
+
+    @Test
+    public void withVectorModule() {
+        Path output = Path.of("withVectorModuleImage");
+        link("jdk.incubator.vector", output);
+        checkSVML(output, true);
+    }
+
+    @Test
+    public void withoutVectorModule() {
+        Path output = Path.of("withoutVectorModuleImage");
+        link("java.base", output);
+        checkSVML(output, false);
+    }
+}

--- a/test/jdk/jdk/incubator/vector/ImageTest.java
+++ b/test/jdk/jdk/incubator/vector/ImageTest.java
@@ -32,6 +32,7 @@ import java.util.spi.ToolProvider;
 /**
  * @test
  * @summary Tests that the SVML shared library is present in an image only when jdk.incubator.vector is present
+ * @requires vm.compiler2.enabled
  * @requires os.arch == "x86_64" | os.arch == "amd64"
  * @requires os.family == "linux" | os.family == "windows"
  * @modules jdk.incubator.vector jdk.jlink

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -333,11 +333,20 @@ public class Platform {
      * Returns absolute path to directory containing shared libraries in the tested JDK.
      */
     public static Path libDir() {
-        Path dir = Paths.get(testJdk);
+        return libDir(Paths.get(testJdk)).toAbsolutePath();
+    }
+
+    /**
+     * Resolves a given path, to a JDK image, to the directory containing shared libraries.
+     *
+     * @param image the path to a JDK image
+     * @return the resolved path to the directory containing shared libraries
+     */
+    public static Path libDir(Path image) {
         if (Platform.isWindows()) {
-            return dir.resolve("bin").toAbsolutePath();
+            return image.resolve("bin");
         } else {
-            return dir.resolve("lib").toAbsolutePath();
+            return image.resolve("lib");
         }
     }
 


### PR DESCRIPTION
Test that when the jdk.incubator.vector module is present that libsvml.so is present, and test the opposite case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268353](https://bugs.openjdk.java.net/browse/JDK-8268353): Test libsvml.so is and is not present in jdk image


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to a0c66bd6a03f86419bd638c73a4a6f61616c72c2
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/47.diff">https://git.openjdk.java.net/jdk17/pull/47.diff</a>

</details>
