### PR TITLE
8268723: Problem list SA core file tests on OSX when using ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -27,9 +27,16 @@
 #
 #############################################################################
 
+vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
+
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8220624   generic-all
 serviceability/sa/CDSJMapClstats.java                         8220624   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
-serviceability/sa/TestHeapDumpForLargeArray.java              8220624   generic-all
-vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
-serviceability/sa/TestJmapCore.java                           8268283 linux-aarch64
+
+serviceability/sa/ClhsdbCDSCore.java                          8268722   macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id1                       8268722   macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id3                       8268722   macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x64
+serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
+serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
+serviceability/sa/TestJmapCoreMetaspace.java                  8268722   macosx-x64


### PR DESCRIPTION
See CR for details. I also relocated AdaptiveBlocking001.java in the list so it is not mixed in with SA tests, and removed serviceability/sa/TestHeapDumpForLargeArray.java since it was moved to the resorucehogs directly long ago, and there is already separate entry that reflects the new location.

Note this is being pushed to JDK17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268723](https://bugs.openjdk.java.net/browse/JDK-8268723): Problem list SA core file tests on OSX when using ZGC


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/50.diff">https://git.openjdk.java.net/jdk17/pull/50.diff</a>

</details>
