### PR TITLE
8268702: JFR diagnostic commands lack argument descriptors when viewed using Platform MBean Server

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
@@ -65,6 +65,9 @@ class JfrStartFlightRecordingDCmd : public JfrDCmd {
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdStart";
   }
+  static int num_arguments() {
+    return 11;
+  }
 };
 
 class JfrDumpFlightRecordingDCmd : public JfrDCmd {
@@ -86,6 +89,9 @@ class JfrDumpFlightRecordingDCmd : public JfrDCmd {
   }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdDump";
+  }
+  static int num_arguments() {
+    return 7;
   }
 };
 
@@ -109,6 +115,9 @@ class JfrCheckFlightRecordingDCmd : public JfrDCmd {
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdCheck";
   }
+  static int num_arguments() {
+    return 2;
+  }
 };
 
 class JfrStopFlightRecordingDCmd : public JfrDCmd {
@@ -130,6 +139,9 @@ class JfrStopFlightRecordingDCmd : public JfrDCmd {
   }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdStop";
+  }
+  static int num_arguments() {
+    return 2;
   }
 };
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -58,7 +58,10 @@ abstract class AbstractDCmd {
     // Called by native
     public abstract String[] printHelp();
 
-    // Called by native
+    // Called by native. The number of arguments for each command is
+    // reported to the DCmdFramework as a hardcoded number in native.
+    // This is to avoid an upcall as part of DcmdFramework enumerating existing commands.
+    // Remember to keep the two sides in synch.
     public abstract Argument[] getArgumentInfos();
 
     // Called by native


### PR DESCRIPTION
Greetings,

this changeset restores the diagnostic command argument descriptors that got lost as part of [JDK-8265271](https://bugs.openjdk.java.net/browse/JDK-8265271) .

Testing: jdk_jfr, manual verification

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268702](https://bugs.openjdk.java.net/browse/JDK-8268702): JFR diagnostic commands lack argument descriptors when viewed using Platform MBean Server


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/57.diff">https://git.openjdk.java.net/jdk17/pull/57.diff</a>

</details>
