### PR TITLE
 8268405: Several regressions 4-17% after CHA changes

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -767,6 +767,9 @@
           "to stress handling of long counted loops: run inner loop"        \
           "for at most jint_max / StressLongCountedLoop")                   \
           range(0, max_juint)                                               \
+                                                                            \
+  product(bool, VerifyReceiverTypes, trueInDebug, DIAGNOSTIC,               \
+          "Verify receiver types at runtime")                               \
 
 // end of C2_FLAGS
 

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -515,6 +515,10 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
 
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
+  if (!allow_inline && _callee->holder()->is_interface()) {
+    // Don't convert the interface call to a direct call guarded by an interface subtype check.
+    return false;
+  }
   CallGenerator* cg = C->call_generator(_callee,
                                         vtable_index(),
                                         false /*call_does_dispatch*/,
@@ -953,12 +957,12 @@ JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
   }
 
   if (kit.stopped()) {
-    // Instance exactly does not matches the desired type.
+    // Instance does not match the predicted type.
     kit.set_jvms(slow_jvms);
     return kit.transfer_exceptions_into_jvms();
   }
 
-  // fall through if the instance exactly matches the desired type
+  // Fall through if the instance matches the desired type.
   kit.replace_in_map(receiver, casted_receiver);
 
   // Make the hot call:

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -72,6 +72,9 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
   Bytecodes::Code bytecode = caller->java_code_at_bci(bci);
   guarantee(callee != NULL, "failed method resolution");
 
+  const bool is_virtual_or_interface = (bytecode == Bytecodes::_invokevirtual) ||
+                                       (bytecode == Bytecodes::_invokeinterface);
+
   // Dtrace currently doesn't work unless all calls are vanilla
   if (env()->dtrace_method_probes()) {
     allow_inline = false;
@@ -164,6 +167,12 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
       bool should_delay = false;
       if (ilt->ok_to_inline(callee, jvms, profile, should_delay)) {
         CallGenerator* cg = CallGenerator::for_inline(callee, expected_uses);
+        if (cg != NULL && is_virtual_or_interface && !callee->is_static()) {
+          CallGenerator* trap_cg = CallGenerator::for_uncommon_trap(callee,
+              Deoptimization::Reason_receiver_constraint, Deoptimization::Action_none);
+
+          cg = CallGenerator::for_guarded_call(callee->holder(), trap_cg, cg);
+        }
         if (cg != NULL) {
           // Delay the inlining of this method to give us the
           // opportunity to perform some high level optimizations
@@ -344,9 +353,14 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
       return CallGenerator::for_virtual_call(callee, vtable_index);
     }
   } else {
-    // Class Hierarchy Analysis or Type Profile reveals a unique target,
-    // or it is a static or special call.
-    return CallGenerator::for_direct_call(callee, should_delay_inlining(callee, jvms));
+    // Class Hierarchy Analysis or Type Profile reveals a unique target, or it is a static or special call.
+    CallGenerator* cg = CallGenerator::for_direct_call(callee, should_delay_inlining(callee, jvms));
+    if (cg != NULL && is_virtual_or_interface && !callee->is_static()) {
+      CallGenerator* trap_cg = CallGenerator::for_uncommon_trap(callee,
+          Deoptimization::Reason_receiver_constraint, Deoptimization::Action_none);
+      cg = CallGenerator::for_guarded_call(callee->holder(), trap_cg, cg);
+    }
+    return cg;
   }
 }
 
@@ -1105,29 +1119,18 @@ ciMethod* Compile::optimize_inlining(ciMethod* caller, ciInstanceKlass* klass, c
     return NULL;
   }
 
-  ciInstanceKlass *ikl = receiver_type->klass()->as_instance_klass();
-  if (ikl->is_loaded() && ikl->is_initialized() && !ikl->is_interface() &&
-      (ikl == actual_receiver || ikl->is_subtype_of(actual_receiver))) {
+  ciInstanceKlass* receiver_klass = receiver_type->klass()->as_instance_klass();
+  if (receiver_klass->is_loaded() && receiver_klass->is_initialized() && !receiver_klass->is_interface() &&
+      (receiver_klass == actual_receiver || receiver_klass->is_subtype_of(actual_receiver))) {
     // ikl is a same or better type than the original actual_receiver,
     // e.g. static receiver from bytecodes.
-    actual_receiver = ikl;
+    actual_receiver = receiver_klass;
     // Is the actual_receiver exact?
     actual_receiver_is_exact = receiver_type->klass_is_exact();
   }
 
   ciInstanceKlass*   calling_klass = caller->holder();
   ciMethod* cha_monomorphic_target = callee->find_monomorphic_target(calling_klass, klass, actual_receiver, check_access);
-
-  // Validate receiver info against target method.
-  if (cha_monomorphic_target != NULL) {
-    bool has_receiver = !cha_monomorphic_target->is_static();
-    bool is_interface_holder = cha_monomorphic_target->holder()->is_interface();
-    if (has_receiver && !is_interface_holder) {
-      if (!cha_monomorphic_target->holder()->is_subtype_of(receiver_type->klass())) {
-        cha_monomorphic_target = NULL; // not a subtype
-      }
-    }
-  }
 
   if (cha_monomorphic_target != NULL) {
     // Hardwiring a virtual.

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2933,7 +2933,9 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
 }
 
 Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
-  if (ExpandSubTypeCheckAtParseTime) {
+  bool expand_subtype_check = C->post_loop_opts_phase() ||   // macro node expansion is over
+                              ExpandSubTypeCheckAtParseTime; // forced expansion
+  if (expand_subtype_check) {
     MergeMemNode* mem = merged_memory();
     Node* ctrl = control();
     Node* subklass = obj_or_subklass;

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -380,7 +380,7 @@ public:
   Category category() const;
 
   static const char* str(const Type* t);
-#endif
+#endif // !PRODUCT
   void typerr(const Type *t) const; // Mixing types error
 
   // Create basic type

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1957,7 +1957,9 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     ScopeDesc*      trap_scope  = cvf->scope();
 
-    if (TraceDeoptimization) {
+    bool is_receiver_constraint_failure = VerifyReceiverTypes && (reason == Deoptimization::Reason_receiver_constraint);
+
+    if (TraceDeoptimization || is_receiver_constraint_failure) {
       ttyLocker ttyl;
       tty->print_cr("  bci=%d pc=" INTPTR_FORMAT ", relative_pc=" INTPTR_FORMAT ", method=%s" JVMCI_ONLY(", debug_id=%d"), trap_scope->bci(), p2i(fr.pc()), fr.pc() - nm->code_begin(), trap_scope->method()->name_and_sig_as_C_string()
 #if INCLUDE_JVMCI
@@ -2016,7 +2018,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
                               trap_method->name_and_sig_as_C_string(), trap_bci, nm->compiler_name());
 
     // Print a bunch of diagnostics, if requested.
-    if (TraceDeoptimization || LogCompilation) {
+    if (TraceDeoptimization || LogCompilation || is_receiver_constraint_failure) {
       ResourceMark rm;
       ttyLocker ttyl;
       char buf[100];
@@ -2108,6 +2110,10 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
       }
     }
     // (End diagnostic printout.)
+
+    if (is_receiver_constraint_failure) {
+      fatal("missing receiver type check");
+    }
 
     // Load class if necessary
     if (unloaded_class_index >= 0) {
@@ -2598,6 +2604,7 @@ const char* Deoptimization::_trap_reason_name[] = {
   "rtm_state_change",
   "unstable_if",
   "unstable_fused_if",
+  "receiver_constraint",
 #if INCLUDE_JVMCI
   "aliasing",
   "transfer_to_interpreter",

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -89,6 +89,7 @@ class Deoptimization : AllStatic {
     Reason_rtm_state_change,      // rtm state change detected
     Reason_unstable_if,           // a branch predicted always false was taken
     Reason_unstable_fused_if,     // fused two ifs that had each one untaken branch. One is now taken.
+    Reason_receiver_constraint,   // receiver subtype check failed
 #if INCLUDE_JVMCI
     Reason_aliasing,              // optimistic assumption about aliasing failed
     Reason_transfer_to_interpreter, // explicit transferToInterpreter()

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2402,6 +2402,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_constant(Deoptimization::Reason_rtm_state_change)               \
   declare_constant(Deoptimization::Reason_unstable_if)                    \
   declare_constant(Deoptimization::Reason_unstable_fused_if)              \
+  declare_constant(Deoptimization::Reason_receiver_constraint)            \
   NOT_ZERO(JVMCI_ONLY(declare_constant(Deoptimization::Reason_aliasing)))                       \
   NOT_ZERO(JVMCI_ONLY(declare_constant(Deoptimization::Reason_transfer_to_interpreter)))        \
   NOT_ZERO(JVMCI_ONLY(declare_constant(Deoptimization::Reason_not_compiled_exception_handler))) \


### PR DESCRIPTION
Recevier validation code in `Compile::optimize_inlining()` added by JDK-8267807 is way too strict. In particular, it rejects perfectly valid cases when unique concrete method comes from a superclass ( `receiver_type->klass() <: 
 cha_monomorphic_target->holder()`).  

Instead of reworking the validation logic, I decided to completely get rid of it and follow John's @rose00 suggestion [1] to perform receiver checks at runtime when needed. As I described earlier [2], receiver checks should never fail unless there's a product bug lurking in the code. Debug builds will assert if it ever happens (controlled by `-XX:+-VerifyReceiverTypes`), but product builds will deoptimize at the call site instead.

(The fix depends on #55 to avoid assertion failures in `Parse::do_field_access()`.)

Testing:
- [x] hs-tier1 - hs-tier6
- [x] manual performance runs (dacapo-jython, in particular)  

[1] https://github.com/openjdk/jdk/pull/4212#discussion_r643467030
[2] https://github.com/openjdk/jdk/pull/4212#discussion_r644377036

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268405](https://bugs.openjdk.java.net/browse/JDK-8268405): Several regressions 4-17% after CHA changes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/60.diff">https://git.openjdk.java.net/jdk17/pull/60.diff</a>

</details>
