### PR TITLE
8268828: ProblemList compiler/intrinsics/VectorizedMismatchTest.java on win-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,6 +70,8 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
+compiler/intrinsics/VectorizedMismatchTest.java 8268482 windows-x64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
A trivial fix to ProblemList compiler/intrinsics/VectorizedMismatchTest.java on win-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268828](https://bugs.openjdk.java.net/browse/JDK-8268828): ProblemList compiler/intrinsics/VectorizedMismatchTest.java on win-x64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/64.diff">https://git.openjdk.java.net/jdk17/pull/64.diff</a>

</details>
