### PR TITLE
8268830: ProblemList 3 serviceability/dcmd/framework tests with ZGC on win-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -40,3 +40,9 @@ serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x
 serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
 serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java                  8268722   macosx-x64
+
+serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
+serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x6
+4
+serviceability/dcmd/framework/VMVersionTest.java              8268433 windows-x6
+4

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -42,7 +42,5 @@ serviceability/sa/TestJmapCore.java                           8268722,8268283   
 serviceability/sa/TestJmapCoreMetaspace.java                  8268722   macosx-x64
 
 serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
-serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x6
-4
-serviceability/dcmd/framework/VMVersionTest.java              8268433 windows-x6
-4
+serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x64
+serviceability/dcmd/framework/VMVersionTest.java              8268433 windows-x64


### PR DESCRIPTION
A trivial fix to ProblemList 3 serviceability/dcmd/framework tests with ZGC on win-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268830](https://bugs.openjdk.java.net/browse/JDK-8268830): ProblemList 3 serviceability/dcmd/framework tests with ZGC on win-x64


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/66.diff">https://git.openjdk.java.net/jdk17/pull/66.diff</a>

</details>
