### PR TITLE
8268676: assert(!ik->is_interface() && !ik->has_subklass()) failed: inconsistent klass hierarchy

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -196,8 +196,14 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
 
   if (!inst_src->klass_is_exact()) {
     ciInstanceKlass* ik = inst_src->klass()->as_instance_klass();
-    assert(!ik->is_interface() && !ik->has_subklass(), "inconsistent klass hierarchy");
-    phase->C->dependencies()->assert_leaf_type(ik);
+    assert(!ik->is_interface(), "inconsistent klass hierarchy");
+    if (ik->has_subklass()) {
+      // Concurrent class loading.
+      // Fail fast and return NodeSentinel to indicate that the transform failed.
+      return NodeSentinel;
+    } else {
+      phase->C->dependencies()->assert_leaf_type(ik);
+    }
   }
 
   ciInstanceKlass* ik = inst_src->klass()->as_instance_klass();


### PR DESCRIPTION
JDK-8267947 disabled the caching for "has_subklass() == false" and it became
more likely to observe class hierarchy changes when concurrent class loading
happens.

`ArrayCopy` optimization may observe an effectively exact klass and proceed,
but the observation can be invalidated later.

Proposed fix turns the problematic assert into a runtime check which bails out
the transformation if src input doesn't have exact klass type anymore.

Testing:
- [x] hs-tier1 - hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268676](https://bugs.openjdk.java.net/browse/JDK-8268676): assert(!ik->is_interface() && !ik->has_subklass()) failed: inconsistent klass hierarchy


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/67.diff">https://git.openjdk.java.net/jdk17/pull/67.diff</a>

</details>
