### PR TITLE
JDK-8268774: Residual logging output written to STDOUT, not STDERR

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
@@ -560,7 +560,8 @@ public class Start {
         // We're done.
         if (options.verbose()) {
             long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
-            log.noticeUsingKey("main.done_in", Long.toString(elapsedMillis));
+            JavadocLog.printRawLines(log.getDiagnosticWriter(),
+                    log.getText("main.done_in", Long.toString(elapsedMillis)));
         }
 
         return returnStatus;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
@@ -199,7 +199,7 @@ public class ToolEnvironment {
         if (quiet) {
             return;
         }
-        log.noticeUsingKey(key);
+        JavadocLog.printRawLines(log.getDiagnosticWriter(), log.getText(key));
     }
 
     /**
@@ -212,7 +212,7 @@ public class ToolEnvironment {
         if (quiet) {
             return;
         }
-        log.noticeUsingKey(key, a1);
+        JavadocLog.printRawLines(log.getDiagnosticWriter(), log.getText(key, a1));
     }
 
     TreePath getTreePath(JCCompilationUnit tree) {

--- a/test/langtools/jdk/javadoc/tool/ToolProviderTest.java
+++ b/test/langtools/jdk/javadoc/tool/ToolProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/tool/ToolProviderTest.java
+++ b/test/langtools/jdk/javadoc/tool/ToolProviderTest.java
@@ -123,7 +123,7 @@ public class ToolProviderTest extends TestRunner {
         String out = swOut.toString();
         String err = swErr.toString();
 
-        if (!out.contains("Loading")) {
+        if (!err.contains("Loading")) {
             error("stdout: unexpected output");
         }
         if (!err.contains("illegal character")) {

--- a/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
+++ b/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
+++ b/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
@@ -155,22 +155,22 @@ public class TestLocaleOption extends TestRunner {
 
     private void testHelloWorld(Path base, Locale defaultLocale, Locale localeOption) throws Exception {
         Path apiDir = base.resolve("api");
-        String stdOut = javadoc(defaultLocale,
+        String stdErr = javadoc(defaultLocale,
                                 localeOption,
                                 "-sourcepath", srcDir.toString(),
                                 "-d", apiDir.toString(),
                                 "p")
                 .writeAll()
-                .getOutput(Task.OutputKind.STDOUT);
+                .getOutput(Task.OutputKind.STDERR);
 
         // check console messages
         if (Objects.equals(defaultLocale, ALLCAPS)) {
-            checkContains(stdOut,
+            checkContains(stdErr,
                     """
                         LOADING SOURCE FILES FOR PACKAGE p...
                         CONSTRUCTING JAVADOC INFORMATION...""");
         } else {
-            checkContains(stdOut,
+            checkContains(stdErr,
                     """
                         Loading source files for package p...
                         Constructing Javadoc information...""");

--- a/test/langtools/jdk/javadoc/tool/testToolStreams/TestToolStreams.java
+++ b/test/langtools/jdk/javadoc/tool/testToolStreams/TestToolStreams.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8268774
+ * @summary  Residual logging output written to STDOUT, not STDERR
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestToolStreams
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+// See also TestReporterStreams for testing doclet/reporter use of streams
+public class TestToolStreams extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestToolStreams tester = new TestToolStreams();
+        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+    }
+
+    ToolBox tb = new ToolBox();
+
+    TestToolStreams() throws IOException {
+        tb.writeJavaFiles(Path.of("src"),
+               """
+                    package p1;
+                    /** Comment 1. */
+                    public class C1 { }""",
+                """
+                    package p2;
+                    /** Comment 2. */
+                    public class C2 { }""");
+    }
+
+    /**
+     * Tests the entry point used by the DocumentationTool API and JavadocTester, in which
+     * all output is written to a single specified writer.
+     */
+    @Test
+    public void testSingleStream(Path base) {
+        test(base, false, Output.OUT, Output.OUT);
+    }
+
+    /**
+     * Tests the entry point used by the launcher, in which output is written to
+     * writers that wrap {@code System.out} and {@code System.err}.
+     */
+    @Test
+    public void testStandardStreams(Path base) {
+        test(base, true, Output.STDOUT, Output.STDERR);
+    }
+
+    void test(Path base, boolean useStdStreams, Output stdOut, Output stdErr) {
+        setOutputDirectoryCheck(DirectoryCheck.NONE);
+        setUseStandardStreams(useStdStreams);
+
+        javadoc("--help");
+        checkExit(Exit.OK);
+
+        if (stdOut != stdErr) {
+            checkIsEmpty(stdErr);
+        }
+
+        checkOutput(stdOut, true,
+                "Usage:");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", "src",
+                "-verbose", // Note: triggers lots of javac messages as well as the javadoc time-taken message
+                "p1",
+                Path.of("src").resolve("p2").resolve("C2.java").toString());
+        checkExit(Exit.OK);
+
+        if (stdOut != stdErr) {
+            checkIsEmpty(stdOut);
+        }
+
+        checkOutput(stdErr, true,
+                "Loading source file src/p2/C2.java...".replace("/", FS),
+                "Loading source files for package p1...",
+                "Constructing Javadoc information",
+                "[done in ", " ms]"
+                );
+    }
+
+    void checkIsEmpty(Output out) {
+        checking("no output to " + out);
+        String s = getOutput(out);
+        if (s.isEmpty()) {
+            passed("no output written to " + out);
+        } else {
+            failed(out + " is not empty");
+        }
+    }
+}


### PR DESCRIPTION
Please review an interim minimal fix to write logging messages from the javadoc tool to STDERR, not STDOUT.

Recent work focussed on the use of the `Reporter` API in doclets, including the standard doclet. This patch aligns the tool code with the same policies as used in the doclet (and indirectly, in javac.)

Given we're in RDP1, the fix is intentionally minimal. The direct use of JavadocLog.printRawLines is a definite code-smell, and the `notice` methods in `ToolEnvironment` are seemingly obsolete and could be replaced by more appropriate API in `JavadocLog`. JDK-8268831 is a follow-up issue to address these issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268774](https://bugs.openjdk.java.net/browse/JDK-8268774): Residual logging output written to STDOUT, not STDERR


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to cb28d35f729b3fbc332246e4505258dd58634057
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to cb28d35f729b3fbc332246e4505258dd58634057


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/68.diff">https://git.openjdk.java.net/jdk17/pull/68.diff</a>

</details>
