### PR TITLE
8265500: Some impls of javax.crypto.Cipher.init() do not throw UnsupportedOperationExc for unsupported modes

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ARCFOURCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ARCFOURCipher.java
@@ -179,14 +179,16 @@ public final class ARCFOURCipher extends CipherSpi {
         init(opmode, key);
     }
 
-    // init method. Check opmode and key, then call init(byte[]).
+    // init method. Check key, then call init(byte[]).
     private void init(int opmode, Key key) throws InvalidKeyException {
+
+        // Cipher.init() already checks opmode to be:
+        // ENCRYPT_MODE/DECRYPT_MODE/WRAP_MODE/UNWRAP_MODE
+
         if (lastKey != null) {
             Arrays.fill(lastKey, (byte)0);
         }
-        if ((opmode < Cipher.ENCRYPT_MODE) || (opmode > Cipher.UNWRAP_MODE)) {
-            throw new InvalidKeyException("Unknown opmode: " + opmode);
-        }
+
         lastKey = getEncodedKey(key);
         init(lastKey);
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -535,12 +535,11 @@ abstract class ChaCha20Cipher extends CipherSpi {
      */
     private void init(int opmode, Key key, byte[] newNonce)
             throws InvalidKeyException {
+        // Cipher.init() already checks opmode to be:
+        // ENCRYPT_MODE/DECRYPT_MODE/WRAP_MODE/UNWRAP_MODE
         if ((opmode == Cipher.WRAP_MODE) || (opmode == Cipher.UNWRAP_MODE)) {
             throw new UnsupportedOperationException(
                     "WRAP_MODE and UNWRAP_MODE are not currently supported");
-        } else if ((opmode != Cipher.ENCRYPT_MODE) &&
-                (opmode != Cipher.DECRYPT_MODE)) {
-            throw new InvalidKeyException("Unknown opmode: " + opmode);
         }
 
         // Make sure that the provided key and nonce are unique before

--- a/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,8 @@ public final class RSACipher extends CipherSpi {
             encrypt = false;
             break;
         default:
-            throw new InvalidKeyException("Unknown mode: " + opmode);
+            // should never happen; checked by Cipher.init()
+            throw new AssertionError("Unknown mode: " + opmode);
         }
         RSAKey rsaKey = RSAKeyFactory.toRSAKey(key);
         if (rsaKey instanceof RSAPublicKey) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -356,9 +356,13 @@ final class P11AEADCipher extends CipherSpi {
                 encrypt = false;
                 requireReinit = false;
                 break;
-            default:
-                throw new InvalidAlgorithmParameterException
+            case Cipher.WRAP_MODE:
+            case Cipher.UNWRAP_MODE:
+                throw new UnsupportedOperationException
                         ("Unsupported mode: " + opmode);
+            default:
+                // should never happen; checked by Cipher.init()
+                throw new AssertionError("Unknown mode: " + opmode);
         }
 
         // decryption without parameters is checked in all engineInit() calls

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -370,9 +370,13 @@ final class P11Cipher extends CipherSpi {
             case Cipher.DECRYPT_MODE:
                 encrypt = false;
                 break;
-            default:
-                throw new InvalidAlgorithmParameterException
+            case Cipher.WRAP_MODE:
+            case Cipher.UNWRAP_MODE:
+                throw new UnsupportedOperationException
                         ("Unsupported mode: " + opmode);
+            default:
+                // should never happen; checked by Cipher.init()
+                throw new AssertionError("Unknown mode: " + opmode);
         }
         if (blockMode == MODE_ECB) { // ECB or stream cipher
             if (iv != null) {

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CRSACipher.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,8 @@ public final class CRSACipher extends CipherSpi {
             encrypt = false;
             break;
         default:
-            throw new InvalidKeyException("Unknown mode: " + opmode);
+            // should never happen; checked by Cipher.init()
+            throw new AssertionError("Unknown mode: " + opmode);
         }
 
         if (!(key instanceof CKey)) {

--- a/test/jdk/javax/crypto/Cipher/TestCipherMode.java
+++ b/test/jdk/javax/crypto/Cipher/TestCipherMode.java
@@ -33,6 +33,7 @@
 
 import java.security.*;
 import java.security.spec.*;
+import java.util.Arrays;
 
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
@@ -40,82 +41,143 @@ import javax.crypto.spec.SecretKeySpec;
 public class TestCipherMode {
 
     private static final String[] TRANSFORMATIONS = {
-        "DES/ECB/PKCS5Padding",
-        "AES/KW/NoPadding",
-        "AES/KW/PKCS5Padding",
-        "AES/KWP/NoPadding",
+        "DES/ECB/PKCS5Padding", // CipherCore
+        "AES/GCM/NoPadding", // GaloisCounterMode
+        "AES/KW/NoPadding", // KeyWrapCipher
+        "AES/KW/PKCS5Padding", // KeyWrapCipher
+        "AES/KWP/NoPadding", // KeyWrapCipher
+        "RSA/ECB/NoPadding", // RSACipher
+        "DESedeWrap/CBC/NoPadding", // DESedeWrapCipher
+        "ChaCha20-Poly1305", // ChaCha20Cipher
     };
 
+    private static final byte[] BYTES32 =
+            Arrays.copyOf(TRANSFORMATIONS[0].getBytes(), 32);
     private static final SecretKey DES_KEY =
-            new SecretKeySpec(new byte[8], "DES");
+            new SecretKeySpec(BYTES32, 0, 8, "DES");
     private static final SecretKey AES_KEY =
-            new SecretKeySpec(new byte[16], "AES");
+            new SecretKeySpec(BYTES32, 0, 16, "AES");
+
+    private  static enum CipherMode {
+        ENCRYPT(Cipher.ENCRYPT_MODE),
+        DECRYPT(Cipher.DECRYPT_MODE),
+        WRAP(Cipher.WRAP_MODE),
+        UNWRAP(Cipher.UNWRAP_MODE),
+        NONEXISTENT(100);
+
+        int value;
+
+        CipherMode(int value) {
+            this.value = value;
+        }
+    }
+
+    private static Key getKey(String t, CipherMode m)
+            throws NoSuchAlgorithmException, NoSuchProviderException {
+        Key key;
+        String algo = t.split("/")[0];
+        switch (algo) {
+        case "AES":
+            key = AES_KEY;
+        break;
+        case "RSA":
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(algo);
+            KeyPair kp = kpg.generateKeyPair();
+            key = ((m == CipherMode.ENCRYPT || m == CipherMode.UNWRAP)?
+                    kp.getPrivate() : kp.getPublic());
+        break;
+        case "ChaCha20-Poly1305":
+            key = new SecretKeySpec(BYTES32, 0, 32, "ChaCha20");
+        break;
+        case "DES":
+            key = new SecretKeySpec(BYTES32, 0, 8, algo);
+        break;
+        case "DESedeWrap":
+            key = new SecretKeySpec(BYTES32, 0, 24, "DESede");
+        break;
+        default:
+            throw new RuntimeException("Unknown transformation: " + t);
+        }
+        return key;
+    }
 
     public static void main(String[] argv) throws Exception {
-        for (String t : TRANSFORMATIONS) {
-            System.out.println("Testing SunJCE provider, Cipher " + t );
 
-            TestCipherMode test = new TestCipherMode(t);
-            System.out.println("Testing ENCRYPT_MODE...");
-            test.checkMode(Cipher.ENCRYPT_MODE, "encryption");
-            System.out.println("Testing DECRYPT_MODE...");
-            test.checkMode(Cipher.DECRYPT_MODE, "decryption");
-            System.out.println("Testing WRAP_MODE...");
-            test.checkMode(Cipher.WRAP_MODE, "key wrapping");
-            System.out.println("Testing UNWRAP_MODE...");
-            test.checkMode(Cipher.UNWRAP_MODE, "key unwrapping");
-        }
+        TestCipherMode test = new TestCipherMode("SunJCE", TRANSFORMATIONS);
         System.out.println("All Tests Passed");
    }
 
     private Cipher c = null;
     private SecretKey key = null;
 
-    private TestCipherMode(String transformation)
-            throws NoSuchAlgorithmException, NoSuchProviderException,
-            NoSuchPaddingException {
-        c = Cipher.getInstance(transformation, "SunJCE");
-        this.key = switch (transformation.split("/")[0]) {
-            case "DES" -> DES_KEY;
-            case "AES" -> AES_KEY;
-            default -> throw new RuntimeException
-                    ("Error: Unsupported key algorithm");
-        };
+    private TestCipherMode(String provName, String... transformations)
+            throws Exception {
+
+        System.out.println("Testing " + provName);
+
+        for (String t : transformations) {
+            for (CipherMode m : CipherMode.values()) {
+                checkMode(t, m, provName);
+            }
+        }
     }
 
-    private void checkMode(int mode, String opString) throws Exception {
-        c.init(mode, key);
+    private void checkMode(String t, CipherMode mode, String provName)
+            throws Exception {
+        Cipher c = Cipher.getInstance(t, provName);
+        Key key = getKey(t, mode);
+
+        System.out.println(c.getAlgorithm() + " with " + mode.name());
+        try {
+            c.init(mode.value, key, c.getParameters());
+            if (mode == CipherMode.NONEXISTENT) {
+                throw new Exception("ERROR: should throw IPE for init()");
+            }
+        } catch (UnsupportedOperationException uoe)  {
+            // some may not support wrap/unwrap or enc/dec
+            if (mode != CipherMode.NONEXISTENT) {
+                System.out.println("Expected UOE thrown with init()");
+                return;
+            }
+            throw uoe;
+        } catch (InvalidParameterException ipe) {
+            if (mode == CipherMode.NONEXISTENT) {
+                System.out.println("=> expected IPE thrown for init()");
+                return;
+            }
+            throw ipe;
+        }
 
         switch (mode) {
-        case Cipher.ENCRYPT_MODE:
-        case Cipher.DECRYPT_MODE:
+        case ENCRYPT:
+        case DECRYPT:
             // call wrap()/unwrap() and see if ISE is thrown.
             try {
                 c.wrap(key);
                 throw new Exception("ERROR: should throw ISE for wrap()");
             } catch (IllegalStateException ise) {
-                System.out.println("expected ISE is thrown for wrap()");
+                System.out.println("=> expected ISE thrown for wrap()");
             }
             try {
                 c.unwrap(new byte[16], key.getAlgorithm(), Cipher.SECRET_KEY);
                 throw new Exception("ERROR: should throw ISE for unwrap()");
             } catch (IllegalStateException ise) {
-                System.out.println("expected ISE is thrown for unwrap()");
+                System.out.println("=> expected ISE thrown for unwrap()");
             }
             break;
-        case Cipher.WRAP_MODE:
-        case Cipher.UNWRAP_MODE:
+        case WRAP:
+        case UNWRAP:
             try {
                 c.update(new byte[16]);
                 throw new Exception("ERROR: should throw ISE for update()");
             } catch (IllegalStateException ise) {
-                System.out.println("expected ISE is thrown for update()");
+                System.out.println("=> expected ISE thrown for update()");
             }
             try {
                 c.doFinal();
                 throw new Exception("ERROR: should throw ISE for doFinal()");
             } catch (IllegalStateException ise) {
-                System.out.println("expected ISE is thrown for doFinal()");
+                System.out.println("=> expected ISE thrown for doFinal()");
             }
             break;
         }

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265500
+ * @summary
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm TestCipherMode
+ */
+
+import java.security.Provider;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.InvalidParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+public class TestCipherMode extends PKCS11Test {
+
+    private static String[] TRANSFORMATIONS = {
+        "AES/ECB/PKCS5Padding", "AES/GCM/NoPadding",
+        "RSA/ECB/PKCS1Padding"
+    };
+
+    private static byte[] BYTES16 =
+            Arrays.copyOf(TRANSFORMATIONS[0].getBytes(), 16);
+    private static SecretKey AES_KEY = new SecretKeySpec(BYTES16, "AES");
+    private static PublicKey RSA_PUBKEY = null;
+    private static PrivateKey RSA_PRIVKEY = null;
+
+    enum CipherMode {
+        ENCRYPT(Cipher.ENCRYPT_MODE),
+        DECRYPT(Cipher.DECRYPT_MODE),
+        WRAP(Cipher.WRAP_MODE),
+        UNWRAP(Cipher.UNWRAP_MODE),
+        NONEXISTENT(100);
+
+        int value;
+
+        CipherMode(int value) {
+            this.value = value;
+        }
+    }
+
+    private static Key getKey(String t, CipherMode m, Provider p)
+            throws NoSuchAlgorithmException {
+        if (t.startsWith("AES")) {
+            return AES_KEY;
+        } else if (t.startsWith("RSA")) {
+            if (RSA_PUBKEY == null) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", p);
+                KeyPair kp = kpg.generateKeyPair();
+                RSA_PUBKEY = kp.getPublic();
+                RSA_PRIVKEY = kp.getPrivate();
+            }
+            return ((m == CipherMode.ENCRYPT || m == CipherMode.UNWRAP)?
+                    RSA_PRIVKEY : RSA_PUBKEY);
+        } else {
+            throw new RuntimeException("Unknown transformation: " + t);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new TestCipherMode(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+
+        // test all cipher impls, e.g. P11Cipher, P11AEADCipher, and
+        // P11RSACipher
+        for (String t : TRANSFORMATIONS) {
+            checkModes(t, p);
+        }
+        System.out.println("All tests passed");
+    }
+
+    private static void checkModes(String t, Provider p) throws Exception {
+        try {
+            Cipher.getInstance(t, p);
+        } catch (Exception e) {
+            System.out.println("Skip " + t + " due to " + e.getMessage());
+            return;
+        }
+
+        for (CipherMode m : CipherMode.values()) {
+            System.out.println("Testing " + t + " with " + m.name());
+            Cipher c;
+            try {
+                c = Cipher.getInstance(t, p);
+                // try init and see if the expected Exception is thrown
+                c.init(m.value, getKey(t, m, p), c.getParameters());
+                if (m == CipherMode.NONEXISTENT) {
+                    throw new Exception("ERROR: should throw IPE with init()");
+                }
+            } catch (UnsupportedOperationException uoe)  {
+                // some may not support wrap/unwrap
+                if (m == CipherMode.WRAP || m == CipherMode.UNWRAP) {
+                    System.out.println("Expected UOE thrown with init()");
+                    continue;
+                }
+                throw uoe;
+            } catch (InvalidParameterException ipe) {
+                if (m == CipherMode.NONEXISTENT) {
+                    System.out.println("Expected IPE thrown for init()");
+                    continue;
+                }
+                throw ipe;
+            }
+            switch (m) {
+            case ENCRYPT:
+            case DECRYPT:
+                // call wrap()/unwrap() and see if ISE is thrown.
+                try {
+                    c.wrap(AES_KEY);
+                    throw new Exception("ERROR: should throw ISE for wrap()");
+                } catch (IllegalStateException ise) {
+                    System.out.println("Expected ISE thrown for wrap()");
+                }
+                try {
+                    c.unwrap(BYTES16, "AES", Cipher.SECRET_KEY);
+                    throw new Exception("ERROR: should throw ISE for unwrap()");
+                } catch (IllegalStateException ise) {
+                    System.out.println("Expected ISE thrown for unwrap()");
+                }
+                break;
+            case WRAP:
+            case UNWRAP:
+                try {
+                    c.update(BYTES16);
+                    throw new Exception("ERROR: should throw ISE for update()");
+                } catch (IllegalStateException ise) {
+                    System.out.println("Expected ISE thrown for update()");
+                }
+                try {
+                    c.doFinal();
+                    throw new Exception("ERROR: should throw ISE for" +
+                            " doFinal()");
+                } catch (IllegalStateException ise) {
+                    System.out.println("Expected ISE thrown for doFinal()");
+                }
+                break;
+            default:
+                throw new AssertionError();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Could someone please help review this trivial fix? The real changes are the two PKCS11 cipher impl classes under src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/. The rest of classes are just cleanups, e.g. dead code or unused code. The test/jdk/javax/crypto/Cipher/TestCipherMode.java is updated to cover more cipher impls for completeness sake. It passes without this fix, so I only add the bug id to the the other test, i.e. test/jdk/sun/security/pkcs11/Cipher/TestCipherMode.java, which verifies the PKCS#11 cipher impls.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265500](https://bugs.openjdk.java.net/browse/JDK-8265500): Some impls of javax.crypto.Cipher.init() do not throw UnsupportedOperationExc for unsupported modes


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/69.diff">https://git.openjdk.java.net/jdk17/pull/69.diff</a>

</details>
