### PR TITLE
8268863: ProblemList serviceability/sa/TestJmapCoreMetaspace.java on linux-x64 with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -39,7 +39,7 @@ serviceability/sa/ClhsdbFindPC.java#id3                       8268722   macosx-x
 serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x64
 serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
 serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
-serviceability/sa/TestJmapCoreMetaspace.java                  8268722   macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   macosx-x64,linux-x64
 
 serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
 serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x64


### PR DESCRIPTION
In order to reduce the noise in the JDK17 CI, I'm ProblemListing serviceability/sa/TestJmapCoreMetaspace.java on linux-x64 with ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268863](https://bugs.openjdk.java.net/browse/JDK-8268863): ProblemList serviceability/sa/TestJmapCoreMetaspace.java on linux-x64 with ZGC


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/72.diff">https://git.openjdk.java.net/jdk17/pull/72.diff</a>

</details>
