### PR TITLE
8268080: java/util/concurrent/forkjoin/AsyncShutdownNow.java fails with java.util.concurrent.RejectedExecutionException

### DIFF
--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -102,7 +103,7 @@ public class AsyncShutdownNow {
             try {
                 future.get();
                 assertTrue(false);
-            } catch (ExecutionException e) {
+            } catch (ExecutionException | RejectedExecutionException e) {
                 // expected
             }
         } finally {
@@ -123,7 +124,7 @@ public class AsyncShutdownNow {
             try {
                 future.get(1, TimeUnit.HOURS);
                 assertTrue(false);
-            } catch (ExecutionException e) {
+            } catch (ExecutionException | RejectedExecutionException e) {
                 // expected
             }
         } finally {
@@ -167,7 +168,7 @@ public class AsyncShutdownNow {
                 // execute long running tasks
                 executor.invokeAny(List.of(SLEEP_FOR_A_DAY, SLEEP_FOR_A_DAY));
                 assertTrue(false);
-            } catch (ExecutionException e) {
+            } catch (ExecutionException | RejectedExecutionException e) {
                 // expected
             }
         } finally {

--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAny.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAny.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAny.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAny.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -89,7 +90,7 @@ public class AsyncShutdownNowInvokeAny {
                     // execute long running tasks
                     pool.invokeAny(List.of(SLEEP_FOR_A_DAY, SLEEP_FOR_A_DAY));
                     assertTrue(false);
-                } catch (ExecutionException e) {
+                } catch (ExecutionException | RejectedExecutionException e) {
                     // expected
                 }
             } finally {


### PR DESCRIPTION
In the methods in question, `RejectedExecutionException` is an expected exception that was previously unhandled (it is a `RuntimeException`, not a subclass of `ExecutionException`). This change adds `RejectedExecutionException` to the existing catch clause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268080](https://bugs.openjdk.java.net/browse/JDK-8268080): java/util/concurrent/forkjoin/AsyncShutdownNow.java fails with java.util.concurrent.RejectedExecutionException


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 9e2f2da14a3b252e2fbb1de50b6553178514ba53
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Contributors
 * Doug Lea `<dl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/74.diff">https://git.openjdk.java.net/jdk17/pull/74.diff</a>

</details>
