### PR TITLE
8268714: [macos-aarch64] 7 java/net/httpclient/websocket tests failed

### DIFF
--- a/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
+++ b/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
@@ -278,6 +278,7 @@ public class ISO_8859_1_Test implements HttpServerAdapters {
 
     @Test(dataProvider = "variants")
     public void test(String uri, boolean sameClient) throws Exception {
+        checkSkip();
         System.out.println("Request to " + uri);
 
         HttpClient client = newHttpClient(sameClient);

--- a/test/jdk/java/net/httpclient/websocket/DummyWebSocketServer.java
+++ b/test/jdk/java/net/httpclient/websocket/DummyWebSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,7 +150,7 @@ public class DummyWebSocketServer implements Closeable {
                         err.println("Error in connection: " + channel + ", " + e);
                     } finally {
                         err.println("Closed: " + channel);
-                        close(channel);
+                        closeChannel(channel);
                         readReady.countDown();
                     }
                 }
@@ -182,6 +182,10 @@ public class DummyWebSocketServer implements Closeable {
             read.put(b);
             b.clear();
         }
+    }
+
+    protected void closeChannel(SocketChannel channel) {
+        close(channel);
     }
 
     protected void write(SocketChannel ch) throws IOException { }

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPingClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.internal.httpclient.websocket.debug=true
  *       PendingBinaryPingClose
@@ -48,6 +49,7 @@ public class PendingBinaryPingClose extends PendingOperations {
     public void pendingBinaryPingClose(boolean last) throws Exception {
         repeatable(() -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingBinaryPongClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.internal.httpclient.websocket.debug=true
  *       PendingBinaryPongClose
@@ -50,6 +51,7 @@ public class PendingBinaryPongClose extends PendingOperations {
     public void pendingBinaryPongClose(boolean last) throws Exception {
         repeatable(() -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingBinaryClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *       PendingPingBinaryClose
  */
 
@@ -50,6 +51,7 @@ public class PendingPingBinaryClose extends PendingOperations {
     public void pendingPingBinaryClose(boolean last) throws Exception {
         repeatable( () -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPingTextClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *       PendingPingTextClose
  */
 
@@ -52,6 +53,7 @@ public class PendingPingTextClose extends PendingOperations {
         try {
             repeatable(() -> {
                 server = Support.notReadingServer();
+                server.setReceiveBufferSize(1024);
                 server.open();
                 webSocket = httpClient().newWebSocketBuilder()
                         .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongBinaryClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *       PendingPongBinaryClose
  */
 
@@ -50,6 +51,7 @@ public class PendingPongBinaryClose extends PendingOperations {
     public void pendingPongBinaryClose(boolean last) throws Exception {
         repeatable( () -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingPongTextClose.java
@@ -25,6 +25,7 @@
  * @test
  * @build DummyWebSocketServer
  * @run testng/othervm
+ *      -Djdk.httpclient.sendBufferSize=8192
  *       PendingPongTextClose
  */
 
@@ -50,6 +51,7 @@ public class PendingPongTextClose extends PendingOperations {
     public void pendingPongTextClose(boolean last) throws Exception {
         repeatable( () -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
+++ b/test/jdk/java/net/httpclient/websocket/PendingTextPongClose.java
@@ -27,6 +27,7 @@
  * @run testng/othervm
  *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.internal.httpclient.websocket.debug=true
+ *      -Djdk.httpclient.sendBufferSize=8192
  *       PendingTextPongClose
  */
 
@@ -49,6 +50,7 @@ public class PendingTextPongClose extends PendingOperations {
     public void pendingTextPongClose(boolean last) throws Exception {
         repeatable(() -> {
             server = Support.notReadingServer();
+            server.setReceiveBufferSize(1024);
             server.open();
             webSocket = httpClient().newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })

--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -404,6 +404,8 @@ public class WebSocketProxyTest {
 
     @BeforeMethod
     public void breakBetweenTests() {
+        System.gc();
+        try {Thread.sleep(100); } catch (InterruptedException x) { /* OK */ }
         System.out.println("\n-------\n");
     }
 }


### PR DESCRIPTION
Hi, 

Please find below a test-only change to fix some intermittent failures observed with the httpclient/websocket tests:
these tests intermittently and randomly fail with ENOMEM ("No buffer space available").

Some machines in our CI seem to allow a higher level of concurrency while being (maybe) configured with lower system resources (such as available buffer space for the TCP stack).

Some of the httpclient/websocket tests attempt to fill the sockets buffers in order to assert some conditions when the buffers are full and writing is paused. When the test process terminates, this leaves behind TCP sockets in the TIME_WAIT state that still hold system buffer resources in case retransmission is needed. When several such tests are run this ends up causing random "No buffer space available" errors on other tests (including these tests themselves) running concurrently or shortly after on the same machine.

This change implements a few tricks to alleviate the situation:
 - configure the tests with smaller send buffers on the client side and receive buffers on the server side, in order to limit how much buffer space is consumed by the test.
 - when the not-reading server is closed, and before the accepted socket is closed, read all available data off the socket buffer in order to free up the buffer space that the test has consumed before closing the socket.
 - in some tests that create a large number of HttpClients, limit the number of clients created in shared client mode, and add a call to System.gc() and a small pause to give time for gc to collect the old clients which are no longer referenced. 
 
 With these changes, I have run the HttpClient tests 200 times on the problematic machines without observing any failures (where previously there was at least a couple of failures per 50 runs). I also ran tier1 once, and tier2 twice and the results came clean.
 
 I am therefore claiming success (even if it might prove temporary ;-) )
 
If these failures come back to haunt the CI again after this fix, a further remediation policy could be to put the httpclient/websocket directory in exclusive test execution mode (in TEST.root) - this seems to work too - but cleaning up garbage in the tests themselves seems preferable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268714](https://bugs.openjdk.java.net/browse/JDK-8268714): [macos-aarch64] 7 java/net/httpclient/websocket tests failed


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/79.diff">https://git.openjdk.java.net/jdk17/pull/79.diff</a>

</details>
