### PR TITLE
8265297: javax/net/ssl/SSLSession/TestEnabledProtocols.java failed with "RuntimeException: java.net.SocketException: Connection reset"

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -38,6 +38,7 @@
  * @author Ram Marti
  */
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
@@ -136,13 +137,13 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
                 e.printStackTrace(System.out);
                 System.out.println("** Success **");
             }
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             // The server side may have closed the socket.
-            if (isConnectionReset(ssle)) {
-                System.out.println("Client SSLException:");
-                ssle.printStackTrace(System.out);
+            if (isConnectionReset(se)) {
+                System.out.println("Client SocketException:");
+                se.printStackTrace(System.out);
             } else {
-                failTest(ssle, "Client got UNEXPECTED SSLException:");
+                failTest(se, "Client got UNEXPECTED Exception:");
             }
 
         } catch (Exception e) {
@@ -150,8 +151,8 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
         }
     }
 
-    private boolean isConnectionReset(SSLException ssle) {
-        Throwable cause = ssle.getCause();
+    private boolean isConnectionReset(IOException ioe) {
+        Throwable cause = ioe instanceof SSLException se ? se.getCause() : ioe;
         return cause instanceof SocketException
                 && "Connection reset".equals(cause.getMessage());
     }


### PR DESCRIPTION
The following test: javax/net/ssl/SSLSession/TestEnabledProtocols.java, is failing intermittently because the client side is expecting a SocketException only if it is wrapped into a SSLException, but it should also expect a SocketException when there is no exception chaining.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265297](https://bugs.openjdk.java.net/browse/JDK-8265297): javax/net/ssl/SSLSession/TestEnabledProtocols.java failed with "RuntimeException: java.net.SocketException: Connection reset"


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/80.diff">https://git.openjdk.java.net/jdk17/pull/80.diff</a>

</details>
