### PR TITLE
8268826: Cleanup Override in Context-Specific Deserialization Filters 

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -668,11 +668,11 @@ public interface ObjectInputFilter {
                     serialFilterFactory = factory;
                 } catch (RuntimeException | ClassNotFoundException | NoSuchMethodException |
                         IllegalAccessException | InstantiationException | InvocationTargetException ex) {
+                    Throwable th = (ex instanceof InvocationTargetException ite) ? ite.getCause() : ex;
                     configLog.log(ERROR,
-                            "Error configuring filter factory", ex);
+                            "Error configuring filter factory", th);
                     // Do not continue if configuration not initialized
-                    throw new ExceptionInInitializerError(
-                            "FilterFactory configuration: jdk.serialFilterFactory: " + ex.getMessage());
+                    throw new ExceptionInInitializerError(th);
                 }
             }
             // Setup shared secrets for RegistryImpl to use.
@@ -808,11 +808,11 @@ public interface ObjectInputFilter {
             if (sm != null) {
                 sm.checkPermission(ObjectStreamConstants.SERIAL_FILTER_PERMISSION);
             }
-            if (serialFilterFactory == null)
-                throw new IllegalStateException("Serial filter factory initialization incomplete");
             if (filterFactoryNoReplace.getAndSet(true)) {
-                throw new IllegalStateException("Cannot replace filter factory: " +
-                        serialFilterFactory.getClass().getName());
+                final String msg = serialFilterFactory != null
+                        ? serialFilterFactory.getClass().getName()
+                        : "initialization incomplete";
+                throw new IllegalStateException("Cannot replace filter factory: " + msg);
             }
             configLog.log(DEBUG,
                     "Setting deserialization filter factory to {0}", filterFactory.getClass().getName());

--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -591,7 +591,6 @@ public interface ObjectInputFilter {
          * Boolean to indicate that the filter factory can not be set or replaced.
          * - an ObjectInputStream has already been created using the current filter factory
          * - has been set on the command line
-         * - jdk.serialFilter is set and jdk.serialFilterFactory is unset, the builtin can not be replaced
          * @see Config#setSerialFilterFactory(BinaryOperator)
          */
         private static final AtomicBoolean filterFactoryNoReplace = new AtomicBoolean();

--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -670,7 +670,7 @@ public interface ObjectInputFilter {
                         IllegalAccessException | InstantiationException | InvocationTargetException ex) {
                     Throwable th = (ex instanceof InvocationTargetException ite) ? ite.getCause() : ex;
                     configLog.log(ERROR,
-                            "Error configuring filter factory", th);
+                            "Error configuring filter factory: {0}", (Object)th);
                     // Do not continue if configuration not initialized
                     throw new ExceptionInInitializerError(th);
                 }

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -194,7 +194,7 @@ public final class StaticProperty {
      * in this method. The caller of this method should take care to ensure
      * that the returned property is not made accessible to untrusted code.</strong>
      *
-     * @return the {@code user.name} system property
+     * @return the {@code jdk.serialFilterFactory} system property
      */
     public static String jdkSerialFilterFactory() {
         return JDK_SERIAL_FILTER_FACTORY;

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -981,14 +981,12 @@ jdk.xml.dsig.secureValidationPolicy=\
 
 
 #
-# Deserialization system-wide filter factory
+# Deserialization JVM-wide filter factory
 #
-# A filter factory class name is used to configure the system-wide filter factory.
-# The filter factory value "OVERRIDE" in combination with setting "jdk.serialFilter"
-# indicates that the builtin filter factory can be overridden by the application.
+# A filter factory class name is used to configure the JVM-wide filter factory.
 # The class must be public, must have a public zero-argument constructor, implement the
-# java.util.stream.BinaryOperator<ObjectInputFilter> interface, provide its implementation and
-# be accessible via the application class loader.
+# java.util.function.BinaryOperator<java.io.ObjectInputFilter> interface, provide its
+# implementation and be accessible via the application class loader.
 # A builtin filter factory is used if no filter factory is defined.
 # See java.io.ObjectInputFilter.Config for more information.
 #
@@ -998,7 +996,7 @@ jdk.xml.dsig.secureValidationPolicy=\
 #jdk.serialFilterFactory=<classname>
 
 #
-# Deserialization system-wide filter
+# Deserialization JVM-wide filter
 #
 # A filter, if configured, is used by the filter factory to provide the filter used by
 # java.io.ObjectInputStream during deserialization to check the contents of the stream.

--- a/test/jdk/java/io/Serializable/serialFilter/FilterWithSecurityManagerTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/FilterWithSecurityManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ public class FilterWithSecurityManagerTest {
     ObjectInputFilter filter;
 
     @BeforeClass
+    @SuppressWarnings("removal")
     public void setup() throws Exception {
         setSecurityManager = System.getSecurityManager() != null;
         Object toDeserialized = Long.MAX_VALUE;
@@ -65,6 +66,7 @@ public class FilterWithSecurityManagerTest {
      * Test that setting process-wide filter is checked by security manager.
      */
     @Test
+    @SuppressWarnings("removal")
     public void testGlobalFilter() throws Exception {
         ObjectInputFilter global = ObjectInputFilter.Config.getSerialFilter();
 
@@ -88,6 +90,7 @@ public class FilterWithSecurityManagerTest {
      * Test that setting specific filter is checked by security manager.
      */
     @Test(dependsOnMethods = { "testGlobalFilter" })
+    @SuppressWarnings("removal")
     public void testSpecificFilter() throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
                 ObjectInputStream ois = new ObjectInputStream(bais)) {

--- a/test/jdk/java/io/Serializable/serialFilter/FilterWithSecurityManagerTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/FilterWithSecurityManagerTest.java
@@ -67,7 +67,7 @@ public class FilterWithSecurityManagerTest {
      */
     @Test
     @SuppressWarnings("removal")
-    public void testGlobalFilter() throws Exception {
+    public void testGlobalFilter() {
         ObjectInputFilter global = ObjectInputFilter.Config.getSerialFilter();
 
         try  {

--- a/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
@@ -142,6 +142,7 @@ public class GlobalFilterTest {
      * If there is no security manager then setting it should work.
      */
     @Test()
+    @SuppressWarnings("removal")
     static void setGlobalFilter() {
         SecurityManager sm = System.getSecurityManager();
         ObjectInputFilter filter = new SerialFilterTest.Validator();

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryExample.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryExample.java
@@ -599,19 +599,28 @@ public class SerialFactoryExample {
             }
 
             /**
-             * Apply the predicate to the class being deserialized, if the class is non-null
-             * and if it returns {@code true}, return the requested status. Otherwise, return UNDECIDED.
+             * Returns a filter that returns {@code ifTrueStatus} or the {@code ifFalseStatus}
+             * based on the predicate of the {@code non-null} class and {@code UNDECIDED}
+             * if the class is {@code null}.
              *
              * @param info the FilterInfo
-             * @return the status of applying the predicate, otherwise {@code UNDECIDED}
+             * @return a filter that returns {@code ifTrueStatus} or the {@code ifFalseStatus}
+             *          based on the predicate of the {@code non-null} class and {@code UNDECIDED}
+             *          if the class is {@code null}
              */
             public ObjectInputFilter.Status checkInput(FilterInfo info) {
                 Class<?> clazz = info.serialClass();
-                return (clazz != null && predicate.test(clazz)) ? ifTrueStatus : ifFalseStatus;
+                Status status = (clazz == null) ? UNDECIDED
+                        : (predicate.test(clazz)) ? ifTrueStatus : ifFalseStatus;
+                return status;
             }
 
+            /**
+             * Return a String describing the filter, its predicate, and true and false status values.
+             * @return a String describing the filter, its predicate, and true and false status values.
+             */
             public String toString() {
-                return "predicate(" + predicate + ")";
+                return "predicate(" + predicate + ", ifTrue: " + ifTrueStatus + ", ifFalse:" + ifFalseStatus+ ")";
             }
         }
 

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryExample.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryExample.java
@@ -47,8 +47,8 @@ import static java.io.ObjectInputFilter.Status.REJECTED;
 import static java.io.ObjectInputFilter.Status.UNDECIDED;
 
 /* @test
- * @run testng/othervm -Djdk.serialFilterTrace=true SerialFactoryExample
- * @run testng/othervm -Djdk.serialFilterFactory=SerialFactoryExample$FilterInThread -Djdk.serialFilterTrace=true SerialFactoryExample
+ * @run testng/othervm SerialFactoryExample
+ * @run testng/othervm -Djdk.serialFilterFactory=SerialFactoryExample$FilterInThread SerialFactoryExample
  * @summary Test SerialFactoryExample
  */
 

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputFilter.Config;
+import java.util.function.BinaryOperator;
+
+/* @test
+ * @run testng/othervm  -Djdk.serialFilterFactory=ForcedError_NoSuchClass SerialFactoryFaults
+ * @run testng/othervm  -Djdk.serialFilterFactory=SerialFactoryFaults$NoPublicConstructor SerialFactoryFaults
+ * @run testng/othervm  -Djdk.serialFilterFactory=SerialFactoryFaults$ConstructorThrows SerialFactoryFaults
+ * @run testng/othervm  -Djdk.serialFilterFactory=SerialFactoryFaults$FactorySetsFactory SerialFactoryFaults
+ * @summary Check cases where the Filter Factory initialization from properties fails
+ */
+
+@Test
+public class SerialFactoryFaults {
+
+    public void initFaultTest() {
+        String factoryName = System.getProperty("jdk.serialFilterFactory");
+        ExceptionInInitializerError ex = Assert.expectThrows(ExceptionInInitializerError.class,
+                () -> Config.getSerialFilterFactory());
+        Throwable cause = ex.getCause();
+
+        if (factoryName.equals("ForcedError_NoSuchClass")) {
+            Assert.assertEquals(cause.getClass(),
+                    ClassNotFoundException.class, "wrong exception");
+        } else if (factoryName.equals("SerialFactoryFaults$NoPublicConstructor")) {
+            Assert.assertEquals(cause.getClass(),
+                    NoSuchMethodException.class, "wrong exception");
+        } else if (factoryName.equals("SerialFactoryFaults$ConstructorThrows")) {
+            Assert.assertEquals(cause.getClass(),
+                    IllegalStateException.class, "wrong exception");
+        } else if (factoryName.equals("SerialFactoryFaults$FactorySetsFactory")) {
+            Assert.assertEquals(cause.getClass(),
+                    IllegalStateException.class, "wrong exception");
+            Assert.assertEquals(cause.getMessage(),
+                    "Cannot replace filter factory: initialization incomplete",
+                    "wrong message");
+        } else {
+            Assert.fail("No test for filter factory: " + factoryName);
+        }
+    }
+
+    /**
+     * Test factory that does not have the required public no-arg constructor.
+     */
+    public static final class NoPublicConstructor
+            implements BinaryOperator<ObjectInputFilter> {
+        private NoPublicConstructor() {
+        }
+
+        public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+            throw new RuntimeException("NYI");
+        }
+    }
+
+    /**
+     * Test factory that has a constructor that throws a runtime exception.
+     */
+    public static final class ConstructorThrows
+            implements BinaryOperator<ObjectInputFilter> {
+        public ConstructorThrows() {
+            throw new IllegalStateException("SerialFactoryFaults$ConstructorThrows");
+        }
+
+        public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+            throw new RuntimeException("NYI");
+        }
+    }
+
+    /**
+     * Test factory that has a constructor tries to set the filter factory.
+     */
+    public static final class FactorySetsFactory
+            implements BinaryOperator<ObjectInputFilter> {
+        public FactorySetsFactory() {
+            Config.setSerialFilterFactory(this);
+        }
+
+        public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+            throw new RuntimeException("NYI");
+        }
+    }
+
+}

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
@@ -39,6 +39,12 @@ import java.util.function.BinaryOperator;
 @Test
 public class SerialFactoryFaults {
 
+    static {
+        // Enable logging
+        System.setProperty("java.util.logging.config.file",
+                System.getProperty("test.src", ".") + "/logging.properties");
+    }
+
     public void initFaultTest() {
         String factoryName = System.getProperty("jdk.serialFilterFactory");
         ExceptionInInitializerError ex = Assert.expectThrows(ExceptionInInitializerError.class,

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
@@ -43,15 +43,16 @@ import java.util.function.BinaryOperator;
 
 /* @test
  * @build SerialFilterFactoryTest
- * @run testng/othervm  SerialFilterFactoryTest
- * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$PropertyFilterFactory SerialFilterFactoryTest
- * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$NotMyFilterFactory SerialFilterFactoryTest
+ * @run testng/othervm SerialFilterFactoryTest
+ * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$PropertyFilterFactory
+ *                     -Djava.util.logging.config.file=${test.src}/logging.properties SerialFilterFactoryTest
+ * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$NotMyFilterFactory
+ *                     -Djava.util.logging.config.file=${test.src}/logging.properties SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy
  *        -Djava.security.properties=${test.src}/java.security-extra-factory
  *        -Djava.security.debug=properties SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy.without.globalFilter SerialFilterFactoryTest
-
  *
  * @summary Test Context-specific Deserialization Filters
  */

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
@@ -44,7 +44,6 @@ import java.util.function.BinaryOperator;
 /* @test
  * @build SerialFilterFactoryTest
  * @run testng/othervm  SerialFilterFactoryTest
- * @run testng/othervm -Djdk.serialFilter="*" -Djdk.serialFilterFactory=OVERRIDE SerialFilterFactoryTest
  * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$PropertyFilterFactory SerialFilterFactoryTest
  * @run testng/othervm -Djdk.serialFilterFactory=SerialFilterFactoryTest$NotMyFilterFactory SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy
@@ -121,6 +120,7 @@ public class SerialFilterFactoryTest {
     /**
      * Returns true if serialFilter actions are ok, either no SM or SM has serialFilter Permission
      */
+    @SuppressWarnings("removal")
     private static boolean hasFilterPerm() {
         boolean hasSerialPerm = true;
         SecurityManager sm = System.getSecurityManager();
@@ -163,6 +163,7 @@ public class SerialFilterFactoryTest {
      * Try to set it again, the second should throw.
      */
     @Test
+    @SuppressWarnings("removal")
     void testSecondSetShouldThrow() {
         if (System.getSecurityManager() != null) {
             // Skip test when running with SM
@@ -198,6 +199,7 @@ public class SerialFilterFactoryTest {
      * @throws ClassNotFoundException for class not found (should not occur)
      */
     @Test(dataProvider="FilterCases")
+    @SuppressWarnings("removal")
     void testCase(MyFilterFactory dynFilterFactory, Validator dynFilter, Validator streamFilter)
                 throws IOException, ClassNotFoundException {
 
@@ -253,7 +255,7 @@ public class SerialFilterFactoryTest {
     // Test that if the property jdk-serialFilterFactory is set, then initial factory has the same classname
     @Test
     void testPropertyFilterFactory() {
-        if (jdkSerialFilterFactoryProp != null && !jdkSerialFilterFactoryProp.equals("OVERRIDE")) {
+        if (jdkSerialFilterFactoryProp != null) {
             Assert.assertEquals(jdkSerialFilterFactory.getClass().getName(), jdkSerialFilterFactoryProp,
                     "jdk.serialFilterFactory property classname mismatch");
         }

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFactoryTest.java
@@ -49,7 +49,6 @@ import java.util.function.BinaryOperator;
  * @run testng/othervm/policy=security.policy
  *        -Djava.security.properties=${test.src}/java.security-extra-factory
  *        -Djava.security.debug=properties SerialFilterFactoryTest
- * @run testng/othervm/fail  -Djdk.serialFilterFactory=ForcedError_NoSuchClass SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy SerialFilterFactoryTest
  * @run testng/othervm/policy=security.policy.without.globalFilter SerialFilterFactoryTest
 

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
@@ -36,7 +36,7 @@ import static java.io.ObjectInputFilter.Status.REJECTED;
 import static java.io.ObjectInputFilter.Status.UNDECIDED;
 
 /* @test
- * @run testng/othervm -Djdk.serialFilterTrace=true SerialFilterFunctionTest
+ * @run testng/othervm SerialFilterFunctionTest
  * @summary ObjectInputFilter.Config Function Tests
  */
 @Test

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
@@ -43,12 +43,6 @@ import static java.io.ObjectInputFilter.Status.UNDECIDED;
 @Test
 public class SerialFilterFunctionTest {
 
-    static {
-        // Enable logging
-        System.setProperty("java.util.logging.config.file",
-                System.getProperty("test.src", ".") + "/logging.properties");
-    }
-
     @Test
     void testMerge() {
         Status[] cases = Status.values();

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterFunctionTest.java
@@ -36,11 +36,18 @@ import static java.io.ObjectInputFilter.Status.REJECTED;
 import static java.io.ObjectInputFilter.Status.UNDECIDED;
 
 /* @test
- * @run testng/othervm SerialFilterFunctionTest
+ * @run testng/othervm -Djava.util.logging.config.file=${test.src}/logging.properties
+ *                      SerialFilterFunctionTest
  * @summary ObjectInputFilter.Config Function Tests
  */
 @Test
 public class SerialFilterFunctionTest {
+
+    static {
+        // Enable logging
+        System.setProperty("java.util.logging.config.file",
+                System.getProperty("test.src", ".") + "/logging.properties");
+    }
 
     @Test
     void testMerge() {

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -53,7 +53,8 @@ import org.testng.annotations.DataProvider;
 /* @test
  * @bug 8234836
  * @build SerialFilterTest
- * @run testng/othervm SerialFilterTest
+ * @run testng/othervm -Djava.util.logging.config.file=${test.src}/logging.properties
+ *                      SerialFilterTest
  * @run testng/othervm -Djdk.serialSetFilterAfterRead=true SerialFilterTest
  *
  * @summary Test ObjectInputFilters using Builtin Filter Factory

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -53,8 +53,8 @@ import org.testng.annotations.DataProvider;
 /* @test
  * @bug 8234836
  * @build SerialFilterTest
- * @run testng/othervm -Djdk.serialFilterTrace=true SerialFilterTest
- * @run testng/othervm -Djdk.serialSetFilterAfterRead=true -Djdk.serialFilterTrace=true SerialFilterTest
+ * @run testng/othervm SerialFilterTest
+ * @run testng/othervm -Djdk.serialSetFilterAfterRead=true SerialFilterTest
  *
  * @summary Test ObjectInputFilters using Builtin Filter Factory
  */

--- a/test/jdk/java/io/Serializable/serialFilter/TEST.properties
+++ b/test/jdk/java/io/Serializable/serialFilter/TEST.properties
@@ -1,2 +1,2 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false
+# Allow substitution of ${test.src}
+allowSmartActionArgs=true

--- a/test/jdk/java/io/Serializable/serialFilter/java.security-extra-factory
+++ b/test/jdk/java/io/Serializable/serialFilter/java.security-extra-factory
@@ -1,4 +1,4 @@
 # Deserialization Input Filter Factory
-# See conf/security/java.security for pattern synatx
+# See conf/security/java.security for pattern syntax
 #
 jdk.serialFilterFactory=SerialFilterFactoryTest$PropertyFilterFactory

--- a/test/jdk/java/io/Serializable/serialFilter/logging.properties
+++ b/test/jdk/java/io/Serializable/serialFilter/logging.properties
@@ -1,75 +1,10 @@
 ############################################################
-#  	Default Logging Configuration File
-#
-# You can use a different file by specifying a filename
-# with the java.util.logging.config.file system property.
-# For example, java -Djava.util.logging.config.file=myfile
+#  	Enable logging of all serialization levels to the console
 ############################################################
 
-############################################################
-#  	Global properties
-############################################################
-
-# "handlers" specifies a comma-separated list of log Handler
-# classes.  These handlers will be installed during VM startup.
-# Note that these classes must be on the system classpath.
-# By default we only configure a ConsoleHandler, which will only
-# show messages at the INFO and above levels.
 handlers= java.util.logging.ConsoleHandler
 
-# To also add the FileHandler, use the following line instead.
-#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
-
-# Default global logging level.
-# This specifies which kinds of events are logged across
-# all loggers.  For any given facility this global level
-# can be overridden by a facility-specific level
-# Note that the ConsoleHandler also has a separate level
-# setting to limit messages printed to the console.
-.level= INFO
-
-############################################################
-# Handler specific properties.
-# Describes specific configuration info for Handlers.
-############################################################
-
-# default file output is in user's home directory.
-java.util.logging.FileHandler.pattern = %h/java%u.log
-java.util.logging.FileHandler.limit = 50000
-java.util.logging.FileHandler.count = 1
-# Default number of locks FileHandler can obtain synchronously.
-# This specifies maximum number of attempts to obtain lock file by FileHandler
-# implemented by incrementing the unique field %u as per FileHandler API documentation.
-java.util.logging.FileHandler.maxLocks = 100
-java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
-
-# Limit the messages that are printed on the console to INFO and above.
-java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-
-# Example to customize the SimpleFormatter output format
-# to print one-line log message like this:
-#     <level>: <log message> [<date/time>]
-#
-# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
 java.util.logging.SimpleFormatter.format=%3$s %4$s %5$s %6$s%n
-
-############################################################
-# Facility-specific properties.
-# Provides extra control for each logger.
-############################################################
-
-java.io.serialization.level = FINER
-
-
-
-
-############################################################
-# Facility-specific properties.
-# Provides extra control for each logger.
-############################################################
-
-# For example, set the com.xyz.foo logger to only log SEVERE
-# messages:
-java.io.serialization.level = FINER
-
+java.io.serialization.level = ALL

--- a/test/jdk/java/io/Serializable/serialFilter/logging.properties
+++ b/test/jdk/java/io/Serializable/serialFilter/logging.properties
@@ -1,0 +1,75 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example, java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma-separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overridden by a facility-specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+# Default number of locks FileHandler can obtain synchronously.
+# This specifies maximum number of attempts to obtain lock file by FileHandler
+# implemented by incrementing the unique field %u as per FileHandler API documentation.
+java.util.logging.FileHandler.maxLocks = 100
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the messages that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+java.util.logging.SimpleFormatter.format=%3$s %4$s %5$s %6$s%n
+
+############################################################
+# Facility-specific properties.
+# Provides extra control for each logger.
+############################################################
+
+java.io.serialization.level = FINER
+
+
+
+
+############################################################
+# Facility-specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+java.io.serialization.level = FINER
+


### PR DESCRIPTION
Remove the unnecessary special case "OVERRIDE" in jdk.serialFilterFactory property.
Fix description in the example of a filter allowing platform classes.
Suppress some warnings about use of SecurityManager in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268826](https://bugs.openjdk.java.net/browse/JDK-8268826): Cleanup Override in Context-Specific Deserialization Filters


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to ca66a7b477ef10a9534f61b2e56d6523fde09e46
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/85.diff">https://git.openjdk.java.net/jdk17/pull/85.diff</a>

</details>
