### PR TITLE
JDK-8264843: Javac crashes with NullPointerException when finding unencoded XML in <pre> tag

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -383,11 +383,11 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                     }
                 }
             }
-        }
 
-        // check for self closing tags, such as <a id="name"/>
-        if (tree.isSelfClosing() && !isSelfClosingAllowed(t)) {
-            env.messages.error(HTML, tree, "dc.tag.self.closing", treeName);
+            // check for self closing tags, such as <a id="name"/>
+            if (tree.isSelfClosing() && !isSelfClosingAllowed(t)) {
+                env.messages.error(HTML, tree, "dc.tag.self.closing", treeName);
+            }
         }
 
         try {

--- a/test/langtools/tools/doclint/html/UnknownTagTest.java
+++ b/test/langtools/tools/doclint/html/UnknownTagTest.java
@@ -1,0 +1,17 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8264843
+ * @summary Javac crashes with NullPointerException when finding unencoded XML in <pre> tag
+ * @library ..
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs -ref UnknownTagTest.out UnknownTagTest.java
+ */
+
+/**
+ * This is an <unknown> tag.
+ * This is an <unknown a=b> tag with attributes.
+ * This is an <unknown/> self-closing tag.
+ */
+public class UnknownTagTest {
+}

--- a/test/langtools/tools/doclint/html/UnknownTagTest.out
+++ b/test/langtools/tools/doclint/html/UnknownTagTest.out
@@ -1,0 +1,10 @@
+UnknownTagTest.java:12: error: unknown tag: unknown
+ * This is an <unknown> tag.
+              ^
+UnknownTagTest.java:13: error: unknown tag: unknown
+ * This is an <unknown a=b> tag with attributes.
+              ^
+UnknownTagTest.java:14: error: unknown tag: unknown
+ * This is an <unknown/> self-closing tag.
+              ^
+3 errors


### PR DESCRIPTION
Please review a simple fix for an NPE in doclint, in JDK 17.

The NPE is caused by checking if an unknown tag is self-closing. The fix is to move the check into the arm of the preceding `if` statement that ensures that the tags is not null.   Effectively, we do not valid whether unknown tags may be self-closing.

The potential for the NPE has been there a long time. The check that triggers the NPE became more likely when we removed support for HTML4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264843](https://bugs.openjdk.java.net/browse/JDK-8264843): Javac crashes with NullPointerException when finding unencoded XML in <pre> tag


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/86.diff">https://git.openjdk.java.net/jdk17/pull/86.diff</a>

</details>
