### PR TITLE
8268672: C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1980,7 +1980,10 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop) || (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
+      if (outer_loop->is_member(u_loop) ||
+          // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+          // the outer loop too
+          (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
         wq.push(u);
       }
     }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1977,10 +1977,10 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
     Node* u = n->fast_out(j);
     assert(check_old_new || old_new[u->_idx] == NULL, "shouldn't have been cloned");
     if (!u->is_CFG() && (!check_old_new || old_new[u->_idx] == NULL)) {
-      Node* c = u->in(0) != NULL ? u->in(0) : phase->get_ctrl(u);
+      Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop)) {
+      if (outer_loop->is_member(u_loop) || (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
         wq.push(u);
       }
     }

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedNodeInInnerLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedNodeInInnerLoop.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8268672
+ * @summary C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestPinnedNodeInInnerLoop TestPinnedNodeInInnerLoop
+ *
+ */
+
+public class TestPinnedNodeInInnerLoop {
+    boolean b;
+    double d;
+    int iArr[];
+
+    public static void main(String[] args) {
+        TestPinnedNodeInInnerLoop t = new TestPinnedNodeInInnerLoop();
+        for (int i = 0; i < 10; i++) {
+            t.test();
+        }
+    }
+
+    void test() {
+        int e = 4, f = -51874, g = 7, h = 0;
+
+        for (; f < 3; ++f) {
+        }
+        while (++g < 2) {
+            if (b) {
+                d = h;
+            } else {
+                iArr[g] = e;
+            }
+        }
+        System.out.println(g);
+    }
+}


### PR DESCRIPTION
This is caused by the fix for 8263303 in which I changed the code of
loop cloning of a strip mined loop so nodes that are pinned in the
outer loop but not referenced by the loop's safepoint are moved out of
the loop before cloning:

https://github.com/openjdk/jdk/commit/d4377afb999f4f03d384ded97771c83ea1c1f513#diff-7b82624b78127158abbce6835eeba196bd062aee59512ec2d4e4c8c7d681573bR1980

The assert failure here is caused by a node that has its control input
set to the inner loop but is assigned control by PhaseIdealLoop out of
the inner loop. The assert fires because the change from 8263303
affects the condition that the assert checks. I still think, in
principle, the fix from 8263303 is the good one so I propose to simply
reorganize the change from 8263303 so the assert doesn't wrongly fire.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268672](https://bugs.openjdk.java.net/browse/JDK-8268672): C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/88.diff">https://git.openjdk.java.net/jdk17/pull/88.diff</a>

</details>
