### PR TITLE
8265073: XML transformation and indentation when using xml:space

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
@@ -53,7 +53,7 @@ import org.xml.sax.SAXException;
  * serializers (xml, html, text ...) that write output to a stream.
  *
  * @xsl.usage internal
- * @LastModified: May 2021
+ * @LastModified: June 2021
  */
 abstract public class ToStream extends SerializerBase {
 
@@ -1893,10 +1893,6 @@ abstract public class ToStream extends SerializerBase {
             throw new SAXException(e);
         }
 
-        // process the attributes now, because after this SAX call they might be gone
-        if (atts != null)
-            addAttributes(atts);
-
         if (m_doIndent) {
             m_ispreserveSpace = m_preserveSpaces.peekOrFalse();
             m_preserveSpaces.push(m_ispreserveSpace);
@@ -1904,6 +1900,10 @@ abstract public class ToStream extends SerializerBase {
             m_childNodeNumStack.add(m_childNodeNum);
             m_childNodeNum = 0;
         }
+
+        // process the attributes now, because after this SAX call they might be gone
+        if (atts != null)
+            addAttributes(atts);
 
         m_elemContext = m_elemContext.push(namespaceURI,localName,name);
         m_isprevtext = false;

--- a/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
@@ -203,8 +203,8 @@ public class PrettyPrintTest {
      * Bug: 8265073
      * source and expected output
      */
-    @DataProvider(name = "preserveSpace")
-    public Object[][] preserveSpace() throws Exception {
+    @DataProvider
+    public Object[][] preserveSpace() {
         return new Object[][]{
             {xml1, expected1},
             {xml2, expected2},
@@ -217,7 +217,8 @@ public class PrettyPrintTest {
      * within the relevant elements.
      * @param xml the source
      * @param expected the expected result
-     * @throws Exception if the test fails
+     * @throws Exception if the assertion fails or an error occurs in the
+     * transform process
      */
     @Test(dataProvider = "preserveSpace")
     public void test(String xml, String expected) throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
@@ -33,8 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -66,7 +64,7 @@ import org.xml.sax.SAXException;
 
 /*
  * @test
- * @bug 6439439 8087303 8174025 8223291 8249867 8261209 8260858
+ * @bug 6439439 8087303 8174025 8223291 8249867 8261209 8260858 8265073
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true -Djava.security.manager=allow common.prettyprint.PrettyPrintTest
  * @run testng/othervm common.prettyprint.PrettyPrintTest
@@ -178,6 +176,53 @@ public class PrettyPrintTest {
             {"yes", false},
             {"", false}
         };
+    }
+
+    private final String xml1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<a><b>element b</b><c>element c</c><d xml:space=\"preserve\">TRUE</d><e>test</e></a>";
+    private final String expected1 = "<a>\n"
+            + "    <b>element b</b>\n"
+            + "    <c>element c</c>\n"
+            + "    <d xml:space=\"preserve\">TRUE</d>\n"
+            + "    <e>test</e>\n"
+            + "</a>\n";
+
+    private final String xml2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<l0><l1><l2 xml:space=\"preserve\">level 2</l2> level 1 <l2>level 2</l2></l1>"
+            + "<l1 xml:space=\"preserve\"><l2>level 2</l2> level 1 <l2>level 2</l2></l1></l0>";
+    private final String expected2 = "<l0>\n"
+            + "    <l1>\n"
+            + "        <l2 xml:space=\"preserve\">level 2</l2>\n"
+            + "         level 1 \n"
+            + "        <l2>level 2</l2>\n"
+            + "    </l1>\n"
+            + "    <l1 xml:space=\"preserve\"><l2>level 2</l2> level 1 <l2>level 2</l2></l1>\n"
+            + "</l0>\n";
+
+    /*
+     * Bug: 8265073
+     * source and expected output
+     */
+    @DataProvider(name = "preserveSpace")
+    public Object[][] preserveSpace() throws Exception {
+        return new Object[][]{
+            {xml1, expected1},
+            {xml2, expected2},
+        };
+    }
+
+    /**
+     * Bug: 8265073
+     * Verifies that the scope of the preserve attribute is applied properly
+     * within the relevant elements.
+     * @param xml the source
+     * @param expected the expected result
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "preserveSpace")
+    public void test(String xml, String expected) throws Exception {
+        String result = transform(null, xml, true, true, false, false, false);
+        Assert.assertEquals(result.replaceAll("\r\n", "\n"), expected);
     }
 
     /*


### PR DESCRIPTION
The issue was that the attribute was processed before the variable was set (e.g. m_preserveSpaces.push). Reversing the order fixed it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265073](https://bugs.openjdk.java.net/browse/JDK-8265073): XML transformation and indentation when using xml:space


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/89.diff">https://git.openjdk.java.net/jdk17/pull/89.diff</a>

</details>
