### PR TITLE
8268971: ProblemList tools/jpackage/windows/WinInstallerIconTest.java on win-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -833,6 +833,8 @@ jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-
 
 # jdk_jpackage
 
+tools/jpackage/windows/WinInstallerIconTest.java 8268404 windows-x64
+
 ############################################################################
 
 # Client manual tests


### PR DESCRIPTION
A trivial fix to ProblemList tools/jpackage/windows/WinInstallerIconTest.java on win-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268971](https://bugs.openjdk.java.net/browse/JDK-8268971): ProblemList tools/jpackage/windows/WinInstallerIconTest.java on win-x64


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/90.diff">https://git.openjdk.java.net/jdk17/pull/90.diff</a>

</details>
