### PR TITLE
8254571: Erroneous generic type inference in a lambda expression with a checked exception

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1217,6 +1217,7 @@ public class DeferredAttr extends JCTree.Visitor {
                     freeArgVars.nonEmpty()) {
                 stuckVars.addAll(freeArgVars);
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getReturnType()));
+                depVars.addAll(inferenceContext.freeVarsIn(descType.getThrownTypes()));
             }
             scanLambdaBody(tree, descType.getReturnType());
         }
@@ -1238,6 +1239,7 @@ public class DeferredAttr extends JCTree.Visitor {
                     tree.getOverloadKind() != JCMemberReference.OverloadKind.UNOVERLOADED) {
                 stuckVars.addAll(freeArgVars);
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getReturnType()));
+                depVars.addAll(inferenceContext.freeVarsIn(descType.getThrownTypes()));
             }
         }
 

--- a/test/langtools/tools/javac/lambda/considerExceptionTVarInStuckExprs/ConsiderExceptionTVarsInStuckExprs.java
+++ b/test/langtools/tools/javac/lambda/considerExceptionTVarInStuckExprs/ConsiderExceptionTVarsInStuckExprs.java
@@ -32,6 +32,7 @@ class ConsiderExceptionTVarsInStuckExprs {
 
     public static void test() {
         outer(nested(x -> mightThrow()));
+        outer(nested(ConsiderExceptionTVarsInStuckExprs::mightThrow2));
     }
 
     static <A> void outer(Object o) {}
@@ -45,4 +46,5 @@ class ConsiderExceptionTVarsInStuckExprs {
     }
 
     static void mightThrow() throws Exception {}
+    static <C> void mightThrow2(C c) throws Exception {}
 }

--- a/test/langtools/tools/javac/lambda/considerExceptionTVarInStuckExprs/ConsiderExceptionTVarsInStuckExprs.java
+++ b/test/langtools/tools/javac/lambda/considerExceptionTVarInStuckExprs/ConsiderExceptionTVarsInStuckExprs.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8254571
+ * @summary Erroneous generic type inference in a lambda expression with a checked exception
+ * @compile ConsiderExceptionTVarsInStuckExprs.java
+ */
+
+class ConsiderExceptionTVarsInStuckExprs {
+
+    public static void test() {
+        outer(nested(x -> mightThrow()));
+    }
+
+    static <A> void outer(Object o) {}
+
+    static <B, C, E extends Throwable> B nested(Fun<C,E> fun) {
+        return null;
+    }
+
+    interface Fun<X, Y extends Throwable> {
+        void m(X t) throws Y;
+    }
+
+    static void mightThrow() throws Exception {}
+}


### PR DESCRIPTION
Hi,

The compiler is issuing an error for code like:

```
class JDK8254571 {
    public static void test() {
        outer(nested(x -> mightThrow()));
    }
    
    static <A> void outer(Object o) {}

    static <B, C, E extends Throwable> B nested(Fun<C,E> fun) {
        return null;
    }

    interface Fun<X, Y extends Throwable> {
        void m(X t) throws Y;
    }

    static void mightThrow() throws Exception {}
} 
```

there are several things at play here:

1) for performance reasons we decided to minimize the number of inference variables popped up when inferring nested generic method invocations, see Infer::roots
2) when an expression is stuck (like in this case this implicit lambda) we decide which inference variables should be present in the related inference context and thrown variables were not part of the equation

So there are three hypothesis here:
1) there is a bug in the code that determines which variables are passed up to the nested inference context, meaning that it is passing less variables than the bare minimum needed
2) there is a bug in determining which inference variables should be extracted from stuck expressions
3) both are buggy

The root cause of this bug is that some types escape from Attr with non instantiated type variables in them. I modified the test case to double check if the issue was not related to lambdas, but then the test passed so in the example above I added:

```
     static <X, Y extends Throwable> Fun<X, Y> mightThrow2() throws Y { return null; }
```

which simulates the lambda and the compiler has no issues compiling this invocation:

```
    outer(nested(mightThrow2()));
```

so summing up, after double checking the logic of the code that minimized the inference context I realized that the issue is not there. The code is sound and its output only depend on its input, so the issue should be on determining the input. So IMO the issue is in what inference variables we extract from stuck expressions, which is one of the inputs to Infer::roots. Looking for what variables we extract from stuck expressions, I realized that the code currently ignores type variables in the throws clause and this is why my proposed fix is addressing this issue.

Comments?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254571](https://bugs.openjdk.java.net/browse/JDK-8254571): Erroneous generic type inference in a lambda expression with a checked exception


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to 343943b9888a7dd7bea106c46906bf228036c518
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to 343943b9888a7dd7bea106c46906bf228036c518


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/91.diff">https://git.openjdk.java.net/jdk17/pull/91.diff</a>

</details>
