### PR TITLE
JDK-8268972: Add default impl for recent new Reporter.print method

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
@@ -94,8 +94,8 @@ public interface Reporter {
      * The positions are all 0-based character offsets from the beginning of content of the file.
      * The positions should satisfy the relation {@code start <= pos <= end}.
      *
-     * @implNote
-     * This implementation throws {@code UnsupportedOperationException}.
+     * @implSpec
+     * This implementation always throws {@code UnsupportedOperationException}.
      * The implementation provided by the {@code javadoc} tool to
      * {@link Doclet#init(Locale, Reporter) initialize} a doclet
      * overrides this implementation.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Reporter.java
@@ -94,6 +94,12 @@ public interface Reporter {
      * The positions are all 0-based character offsets from the beginning of content of the file.
      * The positions should satisfy the relation {@code start <= pos <= end}.
      *
+     * @implNote
+     * This implementation throws {@code UnsupportedOperationException}.
+     * The implementation provided by the {@code javadoc} tool to
+     * {@link Doclet#init(Locale, Reporter) initialize} a doclet
+     * overrides this implementation.
+     *
      * @param kind    the kind of diagnostic
      * @param file    the file
      * @param start   the beginning of the enclosing range
@@ -103,7 +109,9 @@ public interface Reporter {
      *
      * @since 17
      */
-    void print(Diagnostic.Kind kind, FileObject file, int start, int pos, int end, String message);
+    default void print(Diagnostic.Kind kind, FileObject file, int start, int pos, int end, String message) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Returns a writer that can be used to write non-diagnostic output,


### PR DESCRIPTION
Please review a simple fix to add a default implementation for a recent new method on the Reporter interface. (It was an oversight that the default implementation was not provided in the original work.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268972](https://bugs.openjdk.java.net/browse/JDK-8268972): Add default impl for recent new Reporter.print method


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/92.diff">https://git.openjdk.java.net/jdk17/pull/92.diff</a>

</details>
