### PR TITLE
8268903: JFR: RecordingStream::dump is missing @since

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -424,6 +424,8 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      *
      * @see RecordingStream#setMaxAge(Duration)
      * @see RecordingStream#setMaxSize(long)
+     *
+     * @since 17
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination);

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -583,6 +583,8 @@ public final class RemoteRecordingStream implements EventStream {
      *
      * @see RemoteRecordingStream#setMaxAge(Duration)
      * @see RemoteRecordingStream#setMaxSize(long)
+     *
+     * @since 17
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination);


### PR DESCRIPTION
Hi,

Could I have review of a fix that add "since" to two newly added API methods?

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268903](https://bugs.openjdk.java.net/browse/JDK-8268903): JFR: RecordingStream::dump is missing @since


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/93.diff">https://git.openjdk.java.net/jdk17/pull/93.diff</a>

</details>
