### PR TITLE
8268638: semaphores of AsyncLogWriter may be broken when JVM is exiting.

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -133,12 +133,16 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // times. It is no-op if async logging is not established.
 //
 class AsyncLogWriter : public NonJavaThread {
+  class AsyncLogLocker;
+
   static AsyncLogWriter* _instance;
+  // _lock(1) denotes a critional region.
+  Semaphore _lock;
   // _sem is a semaphore whose value denotes how many messages have been enqueued.
   // It decreases in AsyncLogWriter::run()
-  static Semaphore _sem;
+  Semaphore _sem;
   // A lock of IO
-  static Semaphore _io_sem;
+  Semaphore _io_sem;
 
   volatile bool _initialized;
   AsyncLogMap _stats; // statistics for dropped messages


### PR DESCRIPTION
8268638: semaphores of AsyncLogWriter may be broken when JVM is exiting.

Reviewed-by: dholmes, phh
Backport-Of: fa3b44d43811dca8c609d6c61a58680835abf8e3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268638](https://bugs.openjdk.java.net/browse/JDK-8268638): semaphores of AsyncLogWriter may be broken when JVM is exiting.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/95.diff">https://git.openjdk.java.net/jdk17/pull/95.diff</a>

</details>
