### PR TITLE
JDK-8266310: deadlock between System.loadLibrary and JNI FindClass loading another class

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Native libraries are loaded via {@link System#loadLibrary(String)},
@@ -185,7 +186,8 @@ public final class NativeLibraries {
             throw new InternalError(fromClass.getName() + " not allowed to load library");
         }
 
-        synchronized (loadedLibraryNames) {
+        acquireNativeLibraryLock(name);
+        try {
             // find if this library has already been loaded and registered in this NativeLibraries
             NativeLibrary cached = libraries.get(name);
             if (cached != null) {
@@ -202,15 +204,14 @@ public final class NativeLibraries {
              * When a library is being loaded, JNI_OnLoad function can cause
              * another loadLibrary invocation that should succeed.
              *
-             * We use a static stack to hold the list of libraries we are
-             * loading because this can happen only when called by the
-             * same thread because this block is synchronous.
+             * Each thread maintains its own stack to hold the list of
+             * libraries it is loading.
              *
              * If there is a pending load operation for the library, we
-             * immediately return success; otherwise, we raise
-             * UnsatisfiedLinkError.
+             * immediately return success; if the pending load is from
+             * a different class loader, we raise UnsatisfiedLinkError.
              */
-            for (NativeLibraryImpl lib : nativeLibraryContext) {
+            for (NativeLibraryImpl lib : NativeLibraryContext.current()) {
                 if (name.equals(lib.name())) {
                     if (loader == lib.fromClass.getClassLoader()) {
                         return lib;
@@ -223,7 +224,7 @@ public final class NativeLibraries {
 
             NativeLibraryImpl lib = new NativeLibraryImpl(fromClass, name, isBuiltin, isJNI);
             // load the native library
-            nativeLibraryContext.push(lib);
+            NativeLibraryContext.push(lib);
             try {
                 if (!lib.open()) {
                     return null;    // fail to open the native library
@@ -242,12 +243,14 @@ public final class NativeLibraries {
                     CleanerFactory.cleaner().register(loader, lib.unloader());
                 }
             } finally {
-                nativeLibraryContext.pop();
+                NativeLibraryContext.pop();
             }
             // register the loaded native library
             loadedLibraryNames.add(name);
             libraries.put(name, lib);
             return lib;
+        } finally {
+            releaseNativeLibraryLock(name);
         }
     }
 
@@ -295,13 +298,16 @@ public final class NativeLibraries {
             throw new UnsupportedOperationException("explicit unloading cannot be used with auto unloading");
         }
         Objects.requireNonNull(lib);
-        synchronized (loadedLibraryNames) {
+        acquireNativeLibraryLock(lib.name());
+        try {
             NativeLibraryImpl nl = libraries.remove(lib.name());
             if (nl != lib) {
                 throw new IllegalArgumentException(lib.name() + " not loaded by this NativeLibraries instance");
             }
             // unload the native library and also remove from the global name registry
             nl.unloader().run();
+        } finally {
+            releaseNativeLibraryLock(lib.name());
         }
     }
 
@@ -415,17 +421,20 @@ public final class NativeLibraries {
 
         @Override
         public void run() {
-            synchronized (loadedLibraryNames) {
+            acquireNativeLibraryLock(name);
+            try {
                 /* remove the native library name */
                 if (!loadedLibraryNames.remove(name)) {
                     throw new IllegalStateException(name + " has already been unloaded");
                 }
-                nativeLibraryContext.push(UNLOADER);
+                NativeLibraryContext.push(UNLOADER);
                 try {
                     unload(name, isBuiltin, isJNI, handle);
                 } finally {
-                    nativeLibraryContext.pop();
+                    NativeLibraryContext.pop();
                 }
+            } finally {
+                releaseNativeLibraryLock(name);
             }
         }
     }
@@ -443,20 +452,111 @@ public final class NativeLibraries {
     }
 
     // All native libraries we've loaded.
-    // This also serves as the lock to obtain nativeLibraries
-    // and write to nativeLibraryContext.
-    private static final Set<String> loadedLibraryNames = new HashSet<>();
+    private static final Set<String> loadedLibraryNames =
+            ConcurrentHashMap.newKeySet();
+
+    // reentrant lock class that allows exact counting (with external synchronization)
+    @SuppressWarnings("serial")
+    private static final class CountedLock extends ReentrantLock {
+
+        private int counter = 0;
+
+        public void increment() {
+            if (counter == Integer.MAX_VALUE) {
+                // prevent overflow
+                throw new Error("Maximum lock count exceeded");
+            }
+            ++counter;
+        }
+
+        public void decrement() {
+            --counter;
+        }
+
+        public int getCounter() {
+            return counter;
+        }
+    }
+
+    // Maps native library name to the corresponding lock object
+    private static final Map<String, CountedLock> nativeLibraryLockMap =
+            new ConcurrentHashMap<>();
+
+    private static void acquireNativeLibraryLock(String libraryName) {
+        nativeLibraryLockMap.compute(libraryName, (name, currentLock) -> {
+            if (currentLock == null) {
+                currentLock = new CountedLock();
+            }
+            // safe as compute lambda is executed atomically
+            currentLock.increment();
+            return currentLock;
+        }).lock();
+    }
+
+    private static void releaseNativeLibraryLock(String libraryName) {
+        CountedLock lock = nativeLibraryLockMap.computeIfPresent(libraryName, (name, currentLock) -> {
+            if (currentLock.getCounter() == 1) {
+                // unlock and release the object if no other threads are queued
+                currentLock.unlock();
+                // remove the element
+                return null;
+            } else {
+                currentLock.decrement();
+                return currentLock;
+            }
+        });
+        if (lock != null) {
+            lock.unlock();
+        }
+    }
 
     // native libraries being loaded
-    private static Deque<NativeLibraryImpl> nativeLibraryContext = new ArrayDeque<>(8);
+    private static final class NativeLibraryContext {
+
+        // Maps thread object to the native library context stack, maintained by each thread
+        private static Map<Thread, Deque<NativeLibraryImpl>> nativeLibraryThreadContext =
+                new ConcurrentHashMap<>();
+
+        // returns a context associated with the current thread
+        private static Deque<NativeLibraryImpl> current() {
+            return nativeLibraryThreadContext.computeIfAbsent(
+                    Thread.currentThread(),
+                    t -> new ArrayDeque<>(8));
+        }
+
+        private static NativeLibraryImpl peek() {
+            return current().peek();
+        }
+
+        private static void push(NativeLibraryImpl lib) {
+            current().push(lib);
+        }
+
+        private static void pop() {
+            // this does not require synchronization since each
+            // thread has its own context
+            Deque<NativeLibraryImpl> libs = current();
+            libs.pop();
+            if (libs.isEmpty()) {
+                // context can be safely removed once empty
+                nativeLibraryThreadContext.remove(Thread.currentThread());
+            }
+        }
+
+        private static boolean isEmpty() {
+            Deque<NativeLibraryImpl> context =
+                    nativeLibraryThreadContext.get(Thread.currentThread());
+            return (context == null || context.isEmpty());
+        }
+    }
 
     // Invoked in the VM to determine the context class in JNI_OnLoad
     // and JNI_OnUnload
     private static Class<?> getFromClass() {
-        if (nativeLibraryContext.isEmpty()) { // only default library
+        if (NativeLibraryContext.isEmpty()) { // only default library
             return Object.class;
         }
-        return nativeLibraryContext.peek().fromClass;
+        return NativeLibraryContext.peek().fromClass;
     }
 
     // JNI FindClass expects the caller class if invoked from JNI_OnLoad

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/Class1.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Class1 loads a native library that calls ClassLoader.findClass in JNI_OnLoad.
+ * Class1 runs concurrently with another thread that opens a signed jar file.
+ */
+class Class1 {
+    static {
+        System.loadLibrary("loadLibraryDeadlock");
+        System.out.println("Signed jar loaded from native library.");
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryDeadlock class triggers the deadlock between the two
+ * lock objects - ZipFile object and ClassLoader.loadedLibraryNames hashmap.
+ * Thread #2 loads a signed jar which leads to acquiring the lock objects in
+ * natural order (ZipFile then HashMap) - loading a signed jar may involve
+ * Providers initialization. Providers may load native libraries.
+ * Thread #1 acquires the locks in reverse order, first entering loadLibrary
+ * called from Class1, then acquiring ZipFile during the search for a class
+ * triggered from JNI.
+ */
+import java.lang.*;
+
+public class LoadLibraryDeadlock {
+
+    public static void main(String[] args) {
+        Thread t1 = new Thread() {
+            public void run() {
+                try {
+                    // an instance of unsigned class that loads a native library
+                    Class<?> c1 = Class.forName("Class1");
+                    Object o = c1.newInstance();
+                } catch (ClassNotFoundException |
+                         InstantiationException |
+                         IllegalAccessException e) {
+                    System.out.println("Class Class1 not found.");
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        Thread t2 = new Thread() {
+            public void run() {
+                try {
+                    // load a class from a signed jar, which locks the JarFile
+                    Class<?> c2 = Class.forName("p.Class2");
+                    System.out.println("Signed jar loaded.");
+                } catch (ClassNotFoundException e) {
+                    System.out.println("Class Class2 not found.");
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        t2.start();
+        t1.start();
+        try {
+            t1.join();
+            t2.join();
+        } catch (InterruptedException ignore) {
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266310
+ * @summary Checks if there's no deadlock between the two lock objects -
+ *          class loading lock and ClassLoader.loadedLibraryNames hashmap.
+ * @library /test/lib
+ * @build LoadLibraryDeadlock Class1 p.Class2
+ * @run main/othervm/native -Xcheck:jni TestLoadLibraryDeadlock
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.*;
+import jdk.test.lib.util.FileUtils;
+
+import java.lang.ProcessBuilder;
+import java.lang.Process;
+import java.nio.file.Paths;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.spi.ToolProvider;
+
+public class TestLoadLibraryDeadlock {
+
+    private static final ToolProvider JAR = ToolProvider.findFirst("jar")
+            .orElseThrow(() -> new RuntimeException("ToolProvider for jar not found"));
+
+    private static final String KEYSTORE = "keystore.jks";
+    private static final String STOREPASS = "changeit";
+    private static final String KEYPASS = "changeit";
+    private static final String ALIAS = "test";
+    private static final String DNAME = "CN=test";
+    private static final String VALIDITY = "366";
+
+    private static String testClassPath = System.getProperty("test.classes");
+    private static String testLibraryPath = System.getProperty("test.nativepath");
+    private static String classPathSeparator = System.getProperty("path.separator");
+
+    private static OutputAnalyzer runCommand(File workingDirectory, String... commands) throws Throwable {
+        ProcessBuilder pb = new ProcessBuilder(commands);
+        pb.directory(workingDirectory);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return ProcessTools.executeProcess(pb);
+    }
+
+    private static OutputAnalyzer runCommandInTestClassPath(String... commands) throws Throwable {
+        return runCommand(new File(testClassPath), commands);
+    }
+
+    private static OutputAnalyzer genKey() throws Throwable {
+        FileUtils.deleteFileIfExistsWithRetry(
+                Paths.get(testClassPath, KEYSTORE));
+        String keytool = JDKToolFinder.getJDKTool("keytool");
+        return runCommandInTestClassPath(keytool,
+                "-storepass", STOREPASS,
+                "-keypass", KEYPASS,
+                "-keystore", KEYSTORE,
+                "-keyalg", "rsa", "-keysize", "2048",
+                "-genkeypair",
+                "-alias", ALIAS,
+                "-dname", DNAME,
+                "-validity", VALIDITY
+        );
+    }
+
+    private static void createJar(String outputJar, String... classes) throws Throwable {
+        List<String> args = new ArrayList<>();
+        Collections.addAll(args, "cvf", Paths.get(testClassPath, outputJar).toString());
+        for (String c : classes) {
+            Collections.addAll(args, "-C", testClassPath, c);
+        }
+        if (JAR.run(System.out, System.err, args.toArray(new String[0])) != 0) {
+            throw new RuntimeException("jar operation failed");
+        }
+    }
+
+    private static OutputAnalyzer signJar(String jarToSign) throws Throwable {
+        String jarsigner = JDKToolFinder.getJDKTool("jarsigner");
+        return runCommandInTestClassPath(jarsigner,
+                "-keystore", KEYSTORE,
+                "-storepass", STOREPASS,
+                jarToSign, ALIAS
+        );
+    }
+
+    private static Process runJavaCommand(String... command) throws Throwable {
+        String java = JDKToolFinder.getJDKTool("java");
+        List<String> commands = new ArrayList<>();
+        Collections.addAll(commands, java);
+        Collections.addAll(commands, command);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return new ProcessBuilder(commands.toArray(new String[0]))
+                .redirectErrorStream(true)
+                .directory(new File(testClassPath))
+                .start();
+    }
+
+    private static OutputAnalyzer jcmd(long pid, String command) throws Throwable {
+        String jcmd = JDKToolFinder.getJDKTool("jcmd");
+        return runCommandInTestClassPath(jcmd,
+                String.valueOf(pid),
+                command
+        );
+    }
+
+    private static String readAvailable(final InputStream is) throws Throwable {
+        final List<String> list = Collections.synchronizedList(new ArrayList<String>());
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Future<String> future = executor.submit(new Callable<String>() {
+            public String call() {
+                String result = new String();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                try {
+                    while(true) {
+                        String s = reader.readLine();
+                        if (s.length() > 0) {
+                            list.add(s);
+                            result += s + "\n";
+                        }
+                    }
+                } catch (IOException ignore) {}
+                return result;
+            }
+        });
+        try {
+            return future.get(1000, TimeUnit.MILLISECONDS);
+        } catch (Exception ignoreAll) {
+            future.cancel(true);
+            return String.join("\n", list);
+        }
+    }
+
+    private final static long countLines(OutputAnalyzer output, String string) {
+        return output.asLines()
+                     .stream()
+                     .filter(s -> s.contains(string))
+                     .count();
+    }
+
+    private final static void dump(OutputAnalyzer output) {
+        output.asLines()
+              .stream()
+              .forEach(s -> System.out.println(s));
+    }
+
+    public static void main(String[] args) throws Throwable {
+        genKey()
+                .shouldHaveExitValue(0);
+
+        FileUtils.deleteFileIfExistsWithRetry(
+                Paths.get(testClassPath, "a.jar"));
+        FileUtils.deleteFileIfExistsWithRetry(
+                Paths.get(testClassPath, "b.jar"));
+        FileUtils.deleteFileIfExistsWithRetry(
+                Paths.get(testClassPath, "c.jar"));
+
+        createJar("a.jar",
+                "LoadLibraryDeadlock.class",
+                "LoadLibraryDeadlock$1.class",
+                "LoadLibraryDeadlock$2.class");
+
+        createJar("b.jar",
+                "Class1.class");
+
+        createJar("c.jar",
+                "p/Class2.class");
+
+        signJar("c.jar")
+                .shouldHaveExitValue(0);
+
+        // load trigger class
+        Process process = runJavaCommand("-cp",
+                "a.jar" + classPathSeparator +
+                "b.jar" + classPathSeparator +
+                "c.jar",
+                "-Djava.library.path=" + testLibraryPath,
+                "LoadLibraryDeadlock");
+
+        // wait for a while to grab some output
+        process.waitFor(5, TimeUnit.SECONDS);
+
+        // dump available output
+        String output = readAvailable(process.getInputStream());
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(output);
+        dump(outputAnalyzer);
+
+        // if the process is still running, get the thread dump
+        OutputAnalyzer outputAnalyzerJcmd = jcmd(process.pid(), "Thread.print");
+        dump(outputAnalyzerJcmd);
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Java-level deadlock") == 0,
+                "Found a deadlock.");
+
+        // if no deadlock, make sure all components have been loaded
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Class Class1 not found.") == 0,
+                "Unable to load class. Class1 not found.");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Class Class2 not found.") == 0,
+                "Unable to load class. Class2 not found.");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Native library loaded.") > 0,
+                "Unable to load native library.");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Signed jar loaded.") > 0,
+                "Unable to load signed jar.");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Signed jar loaded from native library.") > 0,
+                "Unable to load signed jar from native library.");
+
+        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+            // if the process is still frozen, fail the test even though
+            // the "deadlock" text hasn't been found
+            process.destroyForcibly();
+            Asserts.assertTrue(process.waitFor() == 0,
+                    "Process frozen.");
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include "jni.h"
+
+/*
+ * Native library that loads an arbitrary class from a (signed) jar.
+ * This triggers the search in jars, and the lock in ZipFile is acquired
+ * as a result.
+ */
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    JNIEnv *env;
+    jclass cl;
+
+    printf("Native library loaded.\n");
+    fflush(stdout);
+
+    if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
+        return JNI_EVERSION; /* JNI version not supported */
+    }
+
+    // find any class which triggers the search in jars
+    cl = (*env)->FindClass(env, "p/Class2");
+
+    return JNI_VERSION_1_2;
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/p/Class2.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/p/Class2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Class2 is loaded from Thread #2 that checks jar signature and from
+ * Thread #1 that loads a native library.
+ */
+package p;
+
+class Class2 {}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryUnload class calls ClassLoader.loadedLibrary from multiple threads
+ */
+/*
+ * @test
+ * @bug 8266310
+ * @summary Loads a native library from multiple class loaders and multiple
+ *          threads. This creates a race for loading the library. The winner
+ *          loads the library in two threads. All threads except two would fail
+ *          with UnsatisfiedLinkError when the class being loaded is already
+ *          loaded in a different class loader that won the race. The test
+ *          checks that the loaded class is GC'ed, that means the class loader
+ *          is GC'ed and the native library is unloaded.
+ * @library /test/lib
+ * @build LoadLibraryUnload p.Class1
+ * @run main/othervm/native -Xcheck:jni LoadLibraryUnload
+ */
+import jdk.test.lib.Asserts;
+import jdk.test.lib.util.ForceGC;
+import java.lang.*;
+import java.lang.reflect.*;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import p.Class1;
+
+public class LoadLibraryUnload {
+
+    private static class TestLoader extends URLClassLoader {
+        public TestLoader() throws Exception {
+            super(new URL[] { Path.of(System.getProperty("test.classes")).toUri().toURL() });
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> clazz = findLoadedClass(name);
+                if (clazz == null) {
+                    try {
+                        clazz = findClass(name);
+                    } catch (ClassNotFoundException ignore) {
+                    }
+                    if (clazz == null) {
+                        clazz = super.loadClass(name);
+                    }
+                }
+                return clazz;
+            }
+        }
+    }
+
+    private static class LoadLibraryFromClass implements Runnable {
+        Object object;
+        Method method;
+
+        public LoadLibraryFromClass(Class<?> fromClass) {
+            try {
+                this.object = fromClass.newInstance();
+                this.method = fromClass.getDeclaredMethod("loadLibrary");
+            } catch (ReflectiveOperationException roe) {
+                throw new RuntimeException(roe);
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                method.invoke(object);
+            } catch (ReflectiveOperationException roe) {
+                throw new RuntimeException(roe);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Class<?> clazz = null;
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0 ; i < 5 ; i++) {
+            // 5 loaders and 10 threads in total.
+            // winner loads the library in 2 threads
+            clazz = new TestLoader().loadClass("p.Class1");
+            threads.add(new Thread(new LoadLibraryFromClass(clazz)));
+            threads.add(new Thread(new LoadLibraryFromClass(clazz)));
+        }
+
+        final Set<Throwable> exceptions = ConcurrentHashMap.newKeySet();
+        threads.forEach( t -> {
+            t.setUncaughtExceptionHandler((th, ex) -> {
+                // collect the root cause of each failure
+                Throwable rootCause = ex;
+                while((ex = ex.getCause()) != null) {
+                    rootCause = ex;
+                }
+                exceptions.add(rootCause);
+            });
+            t.start();
+        });
+
+        // wait for all threads to finish
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        // expect all errors to be UnsatisfiedLinkError
+        boolean allAreUnsatisfiedLinkError = exceptions
+                .stream()
+                .map(e -> e instanceof UnsatisfiedLinkError)
+                .reduce(true, (i, a) -> i && a);
+
+        // expect exactly 8 errors
+        Asserts.assertTrue(exceptions.size() == 8,
+                "Expected to see 8 failing threads");
+
+        Asserts.assertTrue(allAreUnsatisfiedLinkError,
+                "All errors have to be UnsatisfiedLinkError");
+
+        WeakReference<Class<?>> wClass = new WeakReference<>(clazz);
+
+        // release strong refs
+        clazz = null;
+        threads = null;
+        exceptions.clear();
+        ForceGC gc = new ForceGC();
+        if (!gc.await(() -> wClass.refersTo(null))) {
+            throw new RuntimeException("Class1 hasn't been GC'ed");
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryUnloadTest ensures all objects (NativeLibrary) are deallocated
+ * when loaded in concurrent mode.
+ */
+/*
+ * @test
+ * @bug 8266310
+ * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
+ *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
+ *          when the native library is loaded from a custom class loader.
+ * @library /test/lib
+ * @build LoadLibraryUnload p.Class1
+ * @run main/othervm/native -Xcheck:jni LoadLibraryUnloadTest
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.*;
+
+import java.lang.ProcessBuilder;
+import java.lang.Process;
+import java.io.File;
+import java.util.*;
+
+public class LoadLibraryUnloadTest {
+
+    private static String testClassPath = System.getProperty("test.classes");
+    private static String testLibraryPath = System.getProperty("test.nativepath");
+    private static String classPathSeparator = System.getProperty("path.separator");
+
+    private static Process runJavaCommand(String... command) throws Throwable {
+        String java = JDKToolFinder.getJDKTool("java");
+        List<String> commands = new ArrayList<>();
+        Collections.addAll(commands, java);
+        Collections.addAll(commands, command);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return new ProcessBuilder(commands.toArray(new String[0]))
+                .redirectErrorStream(true)
+                .directory(new File(testClassPath))
+                .start();
+    }
+
+    private final static long countLines(OutputAnalyzer output, String string) {
+        return output.asLines()
+                     .stream()
+                     .filter(s -> s.contains(string))
+                     .count();
+    }
+
+    private final static void dump(OutputAnalyzer output) {
+        output.asLines()
+              .stream()
+              .forEach(s -> System.out.println(s));
+    }
+
+    public static void main(String[] args) throws Throwable {
+
+        Process process = runJavaCommand(
+                "-Dtest.classes=" + testClassPath,
+                "-Djava.library.path=" + testLibraryPath,
+                "LoadLibraryUnload");
+
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(process);
+        dump(outputAnalyzer);
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Native library loaded from Class1.") == 2,
+                "Native library expected to be loaded in 2 threads.");
+
+        long refCount = countLines(outputAnalyzer, "Native library loaded.");
+
+        Asserts.assertTrue(refCount > 0, "Failed to load native library.");
+
+        System.out.println("Native library loaded in " + refCount + " threads");
+
+        Asserts.assertTrue(refCount == 1, "Native library is loaded more than once.");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Native library unloaded.") == refCount,
+                "Failed to unload native library");
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/libloadLibraryUnload.c
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/libloadLibraryUnload.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include "jni.h"
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    JNIEnv *env;
+
+    printf("Native library loaded.\n");
+    fflush(stdout);
+
+    if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
+        return JNI_EVERSION; /* JNI version not supported */
+    }
+
+    return JNI_VERSION_1_2;
+}
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM *vm, void *reserved) {
+
+    printf("Native library unloaded.\n");
+    fflush(stdout);
+}
+

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Class1 loads a native library.
+ */
+package p;
+
+public class Class1 {
+
+    public Class1() {
+    }
+
+    // method called from java threads
+    public void loadLibrary() throws Exception {
+        System.loadLibrary("loadLibraryUnload");
+        System.out.println("Native library loaded from Class1.");
+    }
+}


### PR DESCRIPTION
Resubmitting the following PR https://github.com/openjdk/jdk/pull/3976 against JDK17.

This fixes the deadlock in ClassLoader between the two lock objects - a lock object associated with the class being loaded, and the ClassLoader.loadedLibraryNames hash map, locked during the native library load operation.

Further details can be found in the original PR.

Testing: jtreg and jck testing with no regressions. A new regression test was developed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266310](https://bugs.openjdk.java.net/browse/JDK-8266310): deadlock between System.loadLibrary and JNI FindClass loading another class


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/96.diff">https://git.openjdk.java.net/jdk17/pull/96.diff</a>

</details>
