### PR TITLE
8268612: a few runtime/memory tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -329,6 +329,7 @@ public class TestLargePagesFlags {
 
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
 
     return output;
   }

--- a/test/hotspot/jtreg/runtime/memory/ReadFromNoaccessArea.java
+++ b/test/hotspot/jtreg/runtime/memory/ReadFromNoaccessArea.java
@@ -62,6 +62,7 @@ public class ReadFromNoaccessArea {
     if (output.getStdout() != null && output.getStdout().contains("WB_ReadFromNoaccessArea method is useless")) {
       throw new SkippedException("There is no protected page in ReservedHeapSpace in these circumstance");
     }
+    output.shouldNotHaveExitValue(0);
     if (Platform.isWindows()) {
       output.shouldContain("EXCEPTION_ACCESS_VIOLATION");
     } else if (Platform.isOSX()) {
@@ -76,7 +77,6 @@ public class ReadFromNoaccessArea {
     // This method calls whitebox method reading from noaccess area
     public static void main(String args[]) throws Exception {
       WhiteBox.getWhiteBox().readFromNoaccessArea();
-      throw new Exception("Call of readFromNoaccessArea succeeded! This is wrong. Crash expected. Test failed.");
     }
   }
 

--- a/test/hotspot/jtreg/runtime/memory/ReserveMemory.java
+++ b/test/hotspot/jtreg/runtime/memory/ReserveMemory.java
@@ -59,6 +59,7 @@ public class ReserveMemory {
           "test");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldNotHaveExitValue(0);
     if (Platform.isWindows()) {
       output.shouldContain("EXCEPTION_ACCESS_VIOLATION");
     } else if (Platform.isOSX()) {

--- a/test/hotspot/jtreg/runtime/memory/ReserveMemory.java
+++ b/test/hotspot/jtreg/runtime/memory/ReserveMemory.java
@@ -44,28 +44,27 @@ import sun.hotspot.WhiteBox;
 public class ReserveMemory {
   public static void main(String args[]) throws Exception {
     if (args.length > 0) {
+      // expected to crash
       WhiteBox.getWhiteBox().readReservedMemory();
-
-      throw new Exception("Read of reserved/uncommitted memory unexpectedly succeeded, expected crash!");
-    }
-
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-          "-Xbootclasspath/a:.",
-          "-XX:+UnlockDiagnosticVMOptions",
-          "-XX:+WhiteBoxAPI",
-          "-XX:-CreateCoredumpOnCrash",
-          "-Xmx128m",
-          "ReserveMemory",
-          "test");
-
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotHaveExitValue(0);
-    if (Platform.isWindows()) {
-      output.shouldContain("EXCEPTION_ACCESS_VIOLATION");
-    } else if (Platform.isOSX()) {
-      output.shouldContain("SIGBUS");
     } else {
-      output.shouldContain("SIGSEGV");
+      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Xbootclasspath/a:.",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-XX:-CreateCoredumpOnCrash",
+            "-Xmx128m",
+            "ReserveMemory",
+            "test");
+
+      OutputAnalyzer output = new OutputAnalyzer(pb.start());
+      output.shouldNotHaveExitValue(0);
+      if (Platform.isWindows()) {
+        output.shouldContain("EXCEPTION_ACCESS_VIOLATION");
+      } else if (Platform.isOSX()) {
+        output.shouldContain("SIGBUS");
+      } else {
+        output.shouldContain("SIGSEGV");
+      }
     }
   }
 }


### PR DESCRIPTION
Hi all,

could you please review this small patch that adds checks of exit code to a few `runtime/memory` tests?
from JBS:
> `ReserveMemory.java`, `ReadFromNoaccessArea.java` and `TestLargePagesFlags.java` tests spawn new JVMs but don't check their exit code which might lead to both type-I and type-II errors

in `ReadFromNoaccessArea.java`, the patch removes throwing of an exception in `DummyClassWithMainTryingToReadFromNoaccessArea` (child process), so we will get 0 as an exit code if/when we don't crash.

testing: `runtime/memory` tests on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268612](https://bugs.openjdk.java.net/browse/JDK-8268612): a few runtime/memory tests don't check exit code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to ab9b807054117d27c934ad756e58db87f5c9242b
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer) ⚠️ Review applies to ab9b807054117d27c934ad756e58db87f5c9242b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/97.diff">https://git.openjdk.java.net/jdk17/pull/97.diff</a>

</details>
