### PR TITLE
8269025: jsig/Testjsig.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/jsig/Testjsig.java
+++ b/test/hotspot/jtreg/runtime/jsig/Testjsig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jsig/Testjsig.java
+++ b/test/hotspot/jtreg/runtime/jsig/Testjsig.java
@@ -53,6 +53,7 @@ public class Testjsig {
 
         // Start the process and check the output
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         output.shouldContain("old handler");
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this small trivial test-only change that adds a check of exit code to `jsig/Testjsig.java` test?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269025](https://bugs.openjdk.java.net/browse/JDK-8269025): jsig/Testjsig.java doesn't check exit code


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/98.diff">https://git.openjdk.java.net/jdk17/pull/98.diff</a>

</details>
