### PR TITLE
8267100: [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -634,8 +634,7 @@ sun.security.krb5.maxReferrals=5
 #
 #
 jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
-    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
-    SHA1 jdkCA & usage SignedJAR & denyAfter 2019-01-01
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224
 
 #
 # Legacy algorithms for certification path (CertPath) processing and
@@ -699,7 +698,7 @@ jdk.security.legacyAlgorithms=SHA1, \
 # See "jdk.certpath.disabledAlgorithms" for syntax descriptions.
 #
 jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
-      DSA keySize < 1024, SHA1 jdkCA & denyAfter 2019-01-01
+      DSA keySize < 1024
 
 #
 # Algorithm restrictions for Secure Socket Layer/Transport Layer Security


### PR DESCRIPTION
Please review this fix to backout the change to Disable SHA-1 Signed JARs from JDK 17 due to a startup performance regression (see https://bugs.openjdk.java.net/browse/JDK-8266971). The plan is to now address the performance issue in JDK 18, which will also allow for more bake time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8267100](https://bugs.openjdk.java.net/browse/JDK-8267100): [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs ⚠️ Issue is not open.


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/100.diff">https://git.openjdk.java.net/jdk17/pull/100.diff</a>

</details>
