### PR TITLE
8264775: ClhsdbFindPC still fails with java.lang.RuntimeException: 'In java stack' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -209,7 +209,8 @@ public class ClhsdbFindPC {
                 cmdStr = "findpc " + stackAddress;
                 cmds = List.of(cmdStr);
                 expStrMap = new HashMap<>();
-                expStrMap.put(cmdStr, List.of("In java stack"));
+                // Note, sometimes a stack address points to a hotspot type, thus allow for "Is of type".
+                expStrMap.put(cmdStr, List.of("(In java stack)|(Is of type)"));
                 runTest(withCore, cmds, expStrMap);
             }
 


### PR DESCRIPTION
Since a stack address can point to a hotspot object, findpc of a stack address should allow for "Is of type..." to be the result, rather than requiring it to be "In java stack". The implementation of findpc checks if the address is a hotspot object before checking if it is the stack, which seems to be what you would want.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264775](https://bugs.openjdk.java.net/browse/JDK-8264775): ClhsdbFindPC still fails with java.lang.RuntimeException: 'In java stack' missing from stdout/stderr


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/101.diff">https://git.openjdk.java.net/jdk17/pull/101.diff</a>

</details>
