### PR TITLE
8269063: Build failure due to VerifyReceiverTypes was not declared after JDK-8268405

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1957,7 +1957,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     ScopeDesc*      trap_scope  = cvf->scope();
 
-    bool is_receiver_constraint_failure = VerifyReceiverTypes && (reason == Deoptimization::Reason_receiver_constraint);
+    bool is_receiver_constraint_failure = COMPILER2_PRESENT(VerifyReceiverTypes &&) (reason == Deoptimization::Reason_receiver_constraint);
 
     if (TraceDeoptimization || is_receiver_constraint_failure) {
       ttyLocker ttyl;


### PR DESCRIPTION
Hi all,

Build is broken if C2 is excluded by `--with-jvm-features=-compiler2` due to `VerifyReceiverTypes` was not declared after JDK-8268405.
Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269063](https://bugs.openjdk.java.net/browse/JDK-8269063): Build failure due to VerifyReceiverTypes was not declared after JDK-8268405


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/103.diff">https://git.openjdk.java.net/jdk17/pull/103.diff</a>

</details>
