### PR TITLE
8269065: [REDO] vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java failed with OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
@@ -24,38 +24,70 @@
 
 /*
  * @test
+ * @modules java.base/jdk.internal.misc
  *
  * @summary converted from VM Testbase vm/mlvm/anonloader/stress/oome/metaspace.
  * VM Testbase keywords: [feature_mlvm, nonconcurrent]
  *
- * @library /test/lib
+ * @library /vmTestbase
+ *          /test/lib
  *
- * @run driver vm.mlvm.anonloader.stress.oome.metaspace.Test
+ * @comment build test class and indify classes
+ * @build vm.mlvm.anonloader.stress.oome.metaspace.Test
+ * @run driver vm.mlvm.share.IndifiedClassesBuilder
+ *
+ * @run main/othervm -XX:MaxRAMPercentage=25 -XX:-UseGCOverheadLimit -XX:MetaspaceSize=10m
+ *                   -XX:MaxMetaspaceSize=20m vm.mlvm.anonloader.stress.oome.metaspace.Test
  */
 
 package vm.mlvm.anonloader.stress.oome.metaspace;
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.util.List;
+import java.io.IOException;
 
-public class Test {
+import vm.mlvm.anonloader.share.AnonkTestee01;
+import vm.mlvm.share.MlvmOOMTest;
+import vm.mlvm.share.MlvmTestExecutor;
+import vm.mlvm.share.Env;
+import vm.share.FileUtils;
 
-    public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-Xshare:off", "-XX:MaxMetaspaceSize=512k", "-version");
-
-        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
-
-        analyzer.shouldNotHaveExitValue(0);
-
-        if (!analyzer.getStdout().contains("OutOfMemoryError")) {
-            throw new RuntimeException("TEST FAIL : no OOME");
-        }
-
-        if (!analyzer.getStdout().contains("Metaspace") &&
-            !analyzer.getStdout().contains("Compressed class space")) {
-            throw new RuntimeException("TEST FAIL : wrong OOME");
+/**
+ * This test loads classes using defineHiddenClass and stores them,
+ * expecting Metaspace OOME.
+ *
+ */
+public class Test extends MlvmOOMTest {
+    @Override
+    protected void checkOOME(OutOfMemoryError oome) {
+        String message = oome.getMessage();
+        if (!"Metaspace".equals(message) && !"Compressed class space".equals(message)) {
+            throw new RuntimeException("TEST FAIL : wrong OOME", oome);
         }
     }
 
+    @Override
+    protected void eatMemory(List<Object> list) {
+        byte[] classBytes = null;
+        try {
+            classBytes = FileUtils.readClass(AnonkTestee01.class.getName());
+        } catch (IOException e) {
+            Env.throwAsUncheckedException(e);
+        }
+        try {
+            while (true) {
+                Lookup lookup = MethodHandles.lookup();
+                Lookup ank_lookup = MethodHandles.privateLookupIn(AnonkTestee01.class, lookup);
+                Class<?> c = ank_lookup.defineHiddenClass(classBytes, true).lookupClass();
+                list.add(c.newInstance());
+             }
+         } catch (InstantiationException | IllegalAccessException e) {
+             Env.throwAsUncheckedException(e);
+         }
+    }
+
+    public static void main(String[] args) {
+        MlvmTestExecutor.launch(args);
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this patch which:
 1) Restore vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
 2) Fix the OOME by adding `-XX:MaxRAMPercentage=25`

Testing:
  - Linux/x64, MacOS/x64

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269065](https://bugs.openjdk.java.net/browse/JDK-8269065): [REDO] vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java failed with OutOfMemoryError


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/104.diff">https://git.openjdk.java.net/jdk17/pull/104.diff</a>

</details>
