### PR TITLE
8260684: vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -160,16 +160,16 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
                 int initialFactor = memoryStrategy.equals(MemoryStrategy.HIGH) ? 1 : (memoryStrategy.equals(MemoryStrategy.LOW) ? 10 : 2);
                 GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                 if (type.equals("class")) {
-                        while (!finalized && getExecutionController().continueExecution()) {
-                                System.runFinalization(); //does not guarantee finalization, but increases the chance
-                                try {
-                                        Thread.sleep(100);
-                                } catch (InterruptedException e) {}
-                                GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
-                        }
-
-                        //provoke gc once more to make finalized object phantom reachable
+                    while (!finalized && getExecutionController().continueExecution()) {
+                        System.runFinalization(); //does not guarantee finalization, but increases the chance
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {}
                         GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
+                    }
+
+                    //provoke gc once more to make finalized object phantom reachable
+                    GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                 }
                 if (!getExecutionController().continueExecution()) {
                     // we were interrrupted by stresser. just exit...
@@ -206,12 +206,12 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
 
         class Referent {
 
-                //We need discard this flag to make second and following checks with type.equals("class") useful
-                public Referent() {
-                                finalized = false;
-                        }
+            //We need discard this flag to make second and following checks with type.equals("class") useful
+            public Referent() {
+                finalized = false;
+            }
 
-                        protected void finalize() {
+            protected void finalize() {
                 finalized = true;
             }
         }


### PR DESCRIPTION
Please review this fix of
vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
to eliminate a race that can lead to the test very occasionally hanging and
eventually timing out.

When the referent being tested by a particular iteration is a finalizable
class, the test invoked eatMemory() repeatedly until the referent's
finalize() function set a flag, then called eatMemory() once more to cause
the reference to be cleared and notified.  The problem with this is that
eatMemory() might trigger its GCs before the finalization thread has dropped
the referent, so the referent is still live and the reference has not been
cleared and notified afterward.

The testing thread then proceeds to wait for the reference to be notified.
This usually doesn't cause a problem because other threads will trigger
further GCs, and the finalization thread will eventually drop the object.
However, if the test is nearing completion and this situation arises in the
last thread running, it will wait forever for the notification that isn't
coming.

While investigating this issue I did a bunch of code cleanup (for example,
there was some really badly formatted code), refactoring, and commenting.
As a result, a large fraction of the test has changed, though mostly in ways
that don't affect it's function.  The first of the two commits in the PR is
a whitespace-only cleanup.  Excluding it may make reviewing easier.

Testing:
Ran the phantom002 test a couple thousand times.

Using a modified version of the test, verified that the described problem
case actually occurs; that is, one eatMemory call is sometimes insufficient
to cause clearing of the reference because the referent is still live on the
finalization thread.

/label hotspot-gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260684](https://bugs.openjdk.java.net/browse/JDK-8260684): vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/106.diff">https://git.openjdk.java.net/jdk17/pull/106.diff</a>

</details>
