### PR TITLE
8267100: [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -634,8 +634,7 @@ sun.security.krb5.maxReferrals=5
 #
 #
 jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
-    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
-    SHA1 jdkCA & usage SignedJAR & denyAfter 2019-01-01
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224
 
 #
 # Legacy algorithms for certification path (CertPath) processing and
@@ -699,7 +698,7 @@ jdk.security.legacyAlgorithms=SHA1, \
 # See "jdk.certpath.disabledAlgorithms" for syntax descriptions.
 #
 jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
-      DSA keySize < 1024, SHA1 jdkCA & denyAfter 2019-01-01
+      DSA keySize < 1024
 
 #
 # Algorithm restrictions for Secure Socket Layer/Transport Layer Security


### PR DESCRIPTION
This is a copy of https://github.com/openjdk/jdk17/pull/100 so that I can integrate the fix for @seanjmullan.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267100](https://bugs.openjdk.java.net/browse/JDK-8267100): [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs ⚠️ Issue is not open.


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Contributors
 * Sean Mullan `<mullan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/113.diff">https://git.openjdk.java.net/jdk17/pull/113.diff</a>

</details>
