### PR TITLE
8266885:  [aarch64] Crash with 'Field too big for insn' for some tests under compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
@@ -263,8 +263,8 @@ public class AArch64TestAssembler extends TestAssembler {
     @Override
     public void emitEpilogue() {
         recordMark(config.MARKID_DEOPT_HANDLER_ENTRY);
-        recordCall(new HotSpotForeignCallTarget(config.handleDeoptStub), 5, true, null);
-        code.emitInt(0x94000000);  // bl <imm26>
+        recordCall(new HotSpotForeignCallTarget(config.handleDeoptStub), 4*4, true, null);
+        emitCall(0xdeaddeaddeadL);
     }
 
     @Override
@@ -285,7 +285,7 @@ public class AArch64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCall(long addr) {
-        emitLoadLong(scratchRegister, addr);
+        emitLoadPointer48(scratchRegister, addr);
         emitBlr(scratchRegister);
     }
 
@@ -320,20 +320,39 @@ public class AArch64TestAssembler extends TestAssembler {
         }
     }
 
+    private void emitLoadPointer32(Register ret, long addr) {
+        long a = addr;
+        long al = a;
+        a >>= 16;
+        long ah = a;
+        a >>= 16;
+        assert a == 0 : "invalid pointer" + Long.toHexString(addr);
+        // Set upper 16 bits first. See MacroAssembler::patch_oop().
+        emitMovz(ret, ((int)ah & 0xffff), 16);
+        emitMovk(ret, ((int)al & 0xffff), 0);
+    }
+
+    private void emitLoadPointer48(Register ret, long addr) {
+        // 48-bit VA
+        long a = addr;
+        emitMovz(ret, ((int)a & 0xffff), 0);
+        a >>= 16;
+        emitMovk(ret, ((int)a & 0xffff), 16);
+        a >>= 16;
+        emitMovk(ret, ((int)a & 0xffff), 32);
+        a >>= 16;
+        assert a == 0 : "invalid pointer" + Long.toHexString(addr);
+    }
+
     @Override
     public Register emitLoadPointer(HotSpotConstant c) {
         recordDataPatchInCode(new ConstantReference((VMConstant) c));
 
         Register ret = newRegister();
         if (c.isCompressed()) {
-            // Set upper 16 bits first. See MacroAssembler::patch_oop().
-            emitMovz(ret, 0xdead, 16);
-            emitMovk(ret, 0xdead, 0);
+            emitLoadPointer32(ret, 0xdeaddeadL);
         } else {
-            // 48-bit VA
-            emitMovz(ret, 0xdead, 0);
-            emitMovk(ret, 0xdead, 16);
-            emitMovk(ret, 0xdead, 32);
+            emitLoadPointer48(ret, 0xdeaddeaddeadL);
         }
         return ret;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266885](https://bugs.openjdk.java.net/browse/JDK-8266885): [aarch64] Crash with 'Field too big for insn' for some tests under compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - Committer)
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/115.diff">https://git.openjdk.java.net/jdk17/pull/115.diff</a>

</details>
