### PR TITLE
8269066: assert(ZAddress::is_marked(addr)) failed: Should be marked

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -194,11 +194,21 @@ int ZBarrierSetC2::estimate_stub_size() const {
 
 static void set_barrier_data(C2Access& access) {
   if (ZBarrierSet::barrier_needed(access.decorators(), access.type())) {
-    if (access.decorators() & ON_WEAK_OOP_REF) {
-      access.set_barrier_data(ZLoadBarrierWeak);
+    uint8_t barrier_data = 0;
+
+    if (access.decorators() & ON_PHANTOM_OOP_REF) {
+      barrier_data |= ZLoadBarrierPhantom;
+    } else if (access.decorators() & ON_WEAK_OOP_REF) {
+      barrier_data |= ZLoadBarrierWeak;
     } else {
-      access.set_barrier_data(ZLoadBarrierStrong);
+      barrier_data |= ZLoadBarrierStrong;
     }
+
+    if (access.decorators() & AS_NO_KEEPALIVE) {
+      barrier_data |= ZLoadBarrierNoKeepalive;
+    }
+
+    access.set_barrier_data(barrier_data);
   }
 }
 


### PR DESCRIPTION
Please review this patch to fix an issue in ZBarrierSetC2.

This problem was spotted when running an updated version of test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java, which used `PhantomReference.refersTo()` (see JIRA).

The root cause of the problem is that `set_barrier_data()` in `zBarrierSetC2.cpp` only checks for `ON_WEAK_OOP_REF` and otherwise defaults to `ON_STRONG_OOP_REF`. With the introduction of `Reference.refersTo()` and `PhantomReference.refersTo()` it should also check for `ON_PHANTOM_OOP_REF` and `AS_NO_KEEPALIVE`, but that was missed. As a result, we generate calls to the wrong load barrier type.

Testing:
  * Tier1-7 using ZGC on Linux/x86.
  * 100+ iterations of test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java (updated version)
  * Manual ad-hoc testing to verify that we generate the correct load barrier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269066](https://bugs.openjdk.java.net/browse/JDK-8269066): assert(ZAddress::is_marked(addr)) failed: Should be marked


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/118.diff">https://git.openjdk.java.net/jdk17/pull/118.diff</a>

</details>
