### PR TITLE
8269125: Klass enqueue element size calculation wrong when traceid value cross compress limit

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrEpochQueue.inline.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrEpochQueue.inline.hpp
@@ -68,7 +68,7 @@ JfrEpochQueue<ElementPolicy>::storage_for_element(JfrEpochQueue<ElementPolicy>::
 template <template <typename> class ElementPolicy>
 void JfrEpochQueue<ElementPolicy>::enqueue(JfrEpochQueue<ElementPolicy>::TypePtr t) {
   assert(t != NULL, "invariant");
-  static size_t element_size = _policy.element_size(t);
+  size_t element_size = _policy.element_size(t);
   BufferPtr buffer = storage_for_element(t, element_size);
   assert(buffer != NULL, "invariant");
   _policy.store_element(t, buffer);


### PR DESCRIPTION
Greetings,

please help review this changeset to address an issue with erroneous size calculations as part of enqueuing compressed vs uncompressed elements representing tagged Klasses as part of the JFR load barrier. This issue was spotted during long-running stress testing which loads a huge quantity of classes (~256 million).

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269125](https://bugs.openjdk.java.net/browse/JDK-8269125): Klass enqueue element size calculation wrong when traceid value cross compress limit


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**) ⚠️ Review applies to 309b36f44e1aafdd5077119e3f77146069c75bbd
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/119.diff">https://git.openjdk.java.net/jdk17/pull/119.diff</a>

</details>
