### PR TITLE
8269064: Dropped messages of AsyncLogWriter cause memleak

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -46,10 +46,7 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
     // drop the enqueueing message.
-    char* s = msg.message();
-    if (s != nullptr) {
-      os::free(s);
-    }
+    os::free(msg.message());
     return;
   }
 

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -46,6 +46,10 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
     // drop the enqueueing message.
+    char* s = msg.message();
+    if (s != nullptr) {
+      os::free(s);
+    }
     return;
   }
 


### PR DESCRIPTION
This patch freed c-strs for the dropped messages. Those c-strs are allocated from os::strdup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269064](https://bugs.openjdk.java.net/browse/JDK-8269064): Dropped messages of AsyncLogWriter cause memleak


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/121.diff">https://git.openjdk.java.net/jdk17/pull/121.diff</a>

</details>
