### PR TITLE
8269036: tools/jpackage/share/AppImagePackageTest.java failed with "hdiutil: create failed - Resource busy"

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -346,7 +346,11 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                 "-volname", APP_NAME.fetchFrom(params),
                 "-ov", protoDMG.toAbsolutePath().toString(),
                 "-fs", "HFS+");
-            IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
+            new RetryExecutor()
+                .setMaxAttemptsCount(10)
+                .setAttemptTimeoutMillis(3000)
+                .setWriteOutputToFile(true)
+                .execute(pb);
         }
 
         // mount temp image

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/RetryExecutor.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/RetryExecutor.java
@@ -32,6 +32,7 @@ public final class RetryExecutor {
     public RetryExecutor() {
         setMaxAttemptsCount(5);
         setAttemptTimeoutMillis(2 * 1000);
+        setWriteOutputToFile(false);
     }
 
     public RetryExecutor setMaxAttemptsCount(int v) {
@@ -41,6 +42,11 @@ public final class RetryExecutor {
 
     public RetryExecutor setAttemptTimeoutMillis(int v) {
         timeoutMillis = v;
+        return this;
+    }
+
+    RetryExecutor setWriteOutputToFile(boolean v) {
+        writeOutputToFile = v;
         return this;
     }
 
@@ -69,11 +75,13 @@ public final class RetryExecutor {
     }
 
     public void execute(String cmdline[]) throws IOException {
-        executeLoop(() -> Executor.of(cmdline));
+        executeLoop(() ->
+                Executor.of(cmdline).setWriteOutputToFile(writeOutputToFile));
     }
 
     public void execute(ProcessBuilder pb) throws IOException {
-        executeLoop(() -> Executor.of(pb));
+        executeLoop(() ->
+                Executor.of(pb).setWriteOutputToFile(writeOutputToFile));
     }
 
     private void executeLoop(Supplier<Executor> execSupplier) throws IOException {
@@ -109,4 +117,5 @@ public final class RetryExecutor {
     private boolean aborted;
     private int attempts;
     private int timeoutMillis;
+    private boolean writeOutputToFile;
 }


### PR DESCRIPTION
Looks like another "Resource busy" issue similar to recent fixes for "hdiutil convert" and "hdiutil detach". Workaround in same way by repeating "create" command. Modified RetryExecutor to pass write to file flag, otherwise "hdiutil create" might deadlock.
Also, repeat is done only for creating DMG using size instead of creating from app image. In some cases create DMG from app image might run for very long time and eventually fail, this is why fallback to create DMG from size was added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269036](https://bugs.openjdk.java.net/browse/JDK-8269036): tools/jpackage/share/AppImagePackageTest.java failed with "hdiutil: create failed - Resource busy"


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/122.diff">https://git.openjdk.java.net/jdk17/pull/122.diff</a>

</details>
