### PR TITLE
8269218: GaloisCounterMode.overlapDetection misses the JDK-8263436 fix again

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -894,7 +894,7 @@ abstract class GaloisCounterMode extends CipherSpi {
                 // if src is read only, then we need a copy
                 if (!src.isReadOnly()) {
                     // If using the heap, check underlying byte[] address.
-                    if (!src.array().equals(dst.array()) ) {
+                    if (src.array() != dst.array()) {
                         return dst;
                     }
 


### PR DESCRIPTION
SonarCloud again complains about GaloisCounterMode.overlapDetection, in the similar way JDK-8263436 did. I think JDK-8255557 accidentally reintroduced the old code.

The tangential question if JDK-8255557 reverted anything else.

Additional testing:
 - [x] `jdk_security` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269218](https://bugs.openjdk.java.net/browse/JDK-8269218): GaloisCounterMode.overlapDetection misses the JDK-8263436 fix again


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/124.diff">https://git.openjdk.java.net/jdk17/pull/124.diff</a>

</details>
