### PR TITLE
8268482: compiler/intrinsics/VectorizedMismatchTest.java failed with failed: length in range

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5343,12 +5343,11 @@ bool LibraryCallKit::inline_vectorizedMismatch() {
   if (do_partial_inline) {
     assert(elem_bt != T_ILLEGAL, "sanity");
 
-    const TypeVect* vt = TypeVect::make(elem_bt, inline_limit);
-
     if (Matcher::match_rule_supported_vector(Op_VectorMaskGen,    inline_limit, elem_bt) &&
         Matcher::match_rule_supported_vector(Op_LoadVectorMasked, inline_limit, elem_bt) &&
         Matcher::match_rule_supported_vector(Op_VectorCmpMasked,  inline_limit, elem_bt)) {
 
+      const TypeVect* vt = TypeVect::make(elem_bt, inline_limit);
       Node* cmp_length = _gvn.transform(new CmpINode(length, intcon(inline_limit)));
       Node* bol_gt     = _gvn.transform(new BoolNode(cmp_length, BoolTest::gt));
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,7 +70,6 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
-compiler/intrinsics/VectorizedMismatchTest.java 8268482 windows-x64
 
 #############################################################################
 


### PR DESCRIPTION
Problem was reported on a virtualized HW which was enabled with non-standard options.
As a safety check postponing the vector type creation un-till HW features needed for partial in-lining are checked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268482](https://bugs.openjdk.java.net/browse/JDK-8268482): compiler/intrinsics/VectorizedMismatchTest.java failed with failed: length in range


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/125.diff">https://git.openjdk.java.net/jdk17/pull/125.diff</a>

</details>
