### PR TITLE
8269246: Scoped ByteBuffer vector access

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -131,7 +131,7 @@ public class ScopedMemoryAccess {
 
     @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
     @Retention(RetentionPolicy.RUNTIME)
-    @interface Scoped { }
+    public @interface Scoped { }
 
     // bulk ops
 

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -31,10 +31,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.ref.Reference;
 import java.io.FileDescriptor;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
 
+import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.vector.VectorSupport;
 
 
 /**
@@ -131,7 +136,7 @@ public class ScopedMemoryAccess {
 
     @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface Scoped { }
+    @interface Scoped { }
 
     // bulk ops
 
@@ -334,6 +339,126 @@ public class ScopedMemoryAccess {
             Reference.reachabilityFence(scope);
         }
     }
+
+    // ByteBuffer vector access ops
+
+    // Buffer access constants, to be initalized when required.
+    // Avoids a null value for NIO_ACCESS, due to class initalization dependencies
+    static final class BufferAccess {
+        // Buffer.address
+        static final long BUFFER_ADDRESS
+                = UNSAFE.objectFieldOffset(Buffer.class, "address");
+
+        // ByteBuffer.hb
+        static final long BYTE_BUFFER_HB
+                = UNSAFE.objectFieldOffset(ByteBuffer.class, "hb");
+
+        @ForceInline
+        static Object bufferBase(ByteBuffer bb) {
+            return UNSAFE.getReference(bb, BYTE_BUFFER_HB);
+        }
+
+        @ForceInline
+        static long bufferAddress(ByteBuffer bb, long offset) {
+            return UNSAFE.getLong(bb, BUFFER_ADDRESS) + offset;
+        }
+
+        static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
+
+        @ForceInline
+        static ScopedMemoryAccess.Scope scope(ByteBuffer bb) {
+            MemorySegmentProxy segmentProxy = NIO_ACCESS.bufferSegment(bb);
+            return segmentProxy != null ?
+                    segmentProxy.scope() : null;
+        }
+    }
+
+    @ForceInline
+    public static
+    <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>>
+    V loadFromByteBuffer(Class<? extends V> vmClass, Class<E> e, int length,
+                          ByteBuffer bb, int offset,
+                          S s,
+                          VectorSupport.LoadOperation<ByteBuffer, V, E, S> defaultImpl) {
+        try {
+            return loadFromByteBufferScoped(
+                    BufferAccess.scope(bb),
+                    vmClass, e, length,
+                    bb, offset,
+                    s,
+                    defaultImpl);
+        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
+            throw new IllegalStateException("This segment is already closed");
+        }
+    }
+
+    @Scoped
+    @ForceInline
+    private static
+    <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>>
+    V loadFromByteBufferScoped(ScopedMemoryAccess.Scope scope,
+                          Class<? extends V> vmClass, Class<E> e, int length,
+                          ByteBuffer bb, int offset,
+                          S s,
+                          VectorSupport.LoadOperation<ByteBuffer, V, E, S> defaultImpl) {
+        try {
+            if (scope != null) {
+                scope.checkValidState();
+            }
+
+            return VectorSupport.load(vmClass, e, length,
+                    BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
+                    bb, offset, s,
+                    defaultImpl);
+        } finally {
+            Reference.reachabilityFence(scope);
+        }
+    }
+
+    @ForceInline
+    public static
+    <V extends VectorSupport.Vector<E>, E>
+    void storeIntoByteBuffer(Class<? extends V> vmClass, Class<E> e, int length,
+                             V v,
+                             ByteBuffer bb, int offset,
+                             VectorSupport.StoreVectorOperation<ByteBuffer, V> defaultImpl) {
+        try {
+            storeIntoByteBufferScoped(
+                    BufferAccess.scope(bb),
+                    vmClass, e, length,
+                    v,
+                    bb, offset,
+                    defaultImpl);
+        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
+            throw new IllegalStateException("This segment is already closed");
+        }
+    }
+
+    @Scoped
+    @ForceInline
+    private static
+    <V extends VectorSupport.Vector<E>, E>
+    void storeIntoByteBufferScoped(ScopedMemoryAccess.Scope scope,
+                                   Class<? extends V> vmClass, Class<E> e, int length,
+                                   V v,
+                                   ByteBuffer bb, int offset,
+                                   VectorSupport.StoreVectorOperation<ByteBuffer, V> defaultImpl) {
+        try {
+            if (scope != null) {
+                scope.checkValidState();
+            }
+
+            VectorSupport.store(vmClass, e, length,
+                    BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
+                    v,
+                    bb, offset,
+                    defaultImpl);
+        } finally {
+            Reference.reachabilityFence(scope);
+        }
+    }
+
+
     // typed-ops here
 
     // Note: all the accessor methods defined below take advantage of argument type profiling

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -25,17 +25,9 @@
 
 package jdk.internal.vm.vector;
 
-import jdk.internal.access.JavaNioAccess;
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.foreign.MemorySegmentProxy;
-import jdk.internal.misc.ScopedMemoryAccess;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.misc.Unsafe;
 
-import java.lang.ref.Reference;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
 import java.util.function.*;
 
 public class VectorSupport {
@@ -44,34 +36,6 @@ public class VectorSupport {
     }
 
     private static final Unsafe U = Unsafe.getUnsafe();
-
-    // Buffer.address
-    static final long BUFFER_ADDRESS
-            = U.objectFieldOffset(Buffer.class, "address");
-
-    // ByteBuffer.hb
-    static final long BYTE_BUFFER_HB
-            = U.objectFieldOffset(ByteBuffer.class, "hb");
-
-    @ForceInline
-    static Object bufferBase(ByteBuffer bb) {
-        return U.getReference(bb, BYTE_BUFFER_HB);
-    }
-
-    @ForceInline
-    static long bufferAddress(ByteBuffer bb, long offset) {
-        return U.getLong(bb, BUFFER_ADDRESS) + offset;
-    }
-
-    static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
-
-    @ForceInline
-    static ScopedMemoryAccess.Scope scope(ByteBuffer bb) {
-        MemorySegmentProxy segmentProxy = NIO_ACCESS.bufferSegment(bb);
-        return segmentProxy != null ?
-                segmentProxy.scope() : null;
-    }
-
 
     // Unary
     public static final int VECTOR_OP_ABS  = 0;
@@ -347,48 +311,6 @@ public class VectorSupport {
         return defaultImpl.load(container, index, s);
     }
 
-    @ForceInline
-    public static
-    <VM, E, S extends VectorSpecies<E>>
-    VM loadFromByteBuffer(Class<? extends VM> vmClass, Class<E> e, int length,
-                          ByteBuffer bb, int offset,
-                          S s,
-                          LoadOperation<ByteBuffer, VM, E, S> defaultImpl) {
-        try {
-            return loadFromByteBufferScoped(
-                    scope(bb),
-                    vmClass, e, length,
-                    bb, offset,
-                    s,
-                    defaultImpl);
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
-            throw new IllegalStateException("This segment is already closed");
-        }
-    }
-
-    @ScopedMemoryAccess.Scoped
-    @ForceInline
-    private static
-    <VM, E, S extends VectorSpecies<E>>
-    VM loadFromByteBufferScoped(ScopedMemoryAccess.Scope scope,
-                          Class<? extends VM> vmClass, Class<E> e, int length,
-                          ByteBuffer bb, int offset,    // Unsafe addressing
-                          S s,     // Arguments for default implementation
-                          LoadOperation<ByteBuffer, VM, E, S> defaultImpl) {
-        try {
-            if (scope != null) {
-                scope.checkValidState();
-            }
-
-            return load(vmClass, e, length,
-                    bufferBase(bb), bufferAddress(bb, offset),
-                    bb, offset, s,
-                    defaultImpl);
-        } finally {
-            Reference.reachabilityFence(scope);
-        }
-    }
-
     /* ============================================================================ */
 
     public interface LoadVectorOperationWithMap<C, V extends Vector<?>, E, S extends VectorSpecies<E>> {
@@ -423,49 +345,6 @@ public class VectorSupport {
                StoreVectorOperation<C, V> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v);
-    }
-
-    @ForceInline
-    public static
-    <V extends Vector<?>>
-    void storeIntoByteBuffer(Class<?> vmClass, Class<?> e, int length,
-                             V v,
-                             ByteBuffer bb, int offset,
-                             StoreVectorOperation<ByteBuffer, V> defaultImpl) {
-        try {
-            storeIntoByteBufferScoped(
-                    scope(bb),
-                    vmClass, e, length,
-                    v,
-                    bb, offset,
-                    defaultImpl);
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
-            throw new IllegalStateException("This segment is already closed");
-        }
-    }
-
-    @ScopedMemoryAccess.Scoped
-    @ForceInline
-    private static
-    <V extends Vector<?>>
-    void storeIntoByteBufferScoped(ScopedMemoryAccess.Scope scope,
-                                   Class<?> vmClass, Class<?> e, int length,
-                                   V v,
-                                   ByteBuffer bb, int offset,
-                                   StoreVectorOperation<ByteBuffer, V> defaultImpl) {
-        try {
-            if (scope != null) {
-                scope.checkValidState();
-            }
-
-            store(vmClass, e, length,
-                    bufferBase(bb), bufferAddress(bb, offset),
-                    v,
-                    bb, offset,
-                    defaultImpl);
-        } finally {
-            Reference.reachabilityFence(scope);
-        }
     }
 
     /* ============================================================================ */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3562,7 +3563,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     ByteVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         ByteSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3612,7 +3613,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         ByteSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3562,15 +3562,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     ByteVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         ByteSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.get(o + i * 1));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.get(o + i * 1));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3613,15 +3612,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         ByteSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.put(o + i * 1, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.put(o + i * 1, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3173,7 +3174,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     DoubleVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         DoubleSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3223,7 +3224,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         DoubleSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3173,15 +3173,14 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     DoubleVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         DoubleSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.getDouble(o + i * 8));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.getDouble(o + i * 8));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3224,15 +3223,14 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         DoubleSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.putDouble(o + i * 8, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.putDouble(o + i * 8, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3160,7 +3161,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     FloatVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         FloatSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3210,7 +3211,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         FloatSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3160,15 +3160,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     FloatVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         FloatSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.getFloat(o + i * 4));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.getFloat(o + i * 4));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3211,15 +3210,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         FloatSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.putFloat(o + i * 4, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.putFloat(o + i * 4, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3269,7 +3270,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     IntVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         IntSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3319,7 +3320,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         IntSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3269,15 +3269,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     IntVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         IntSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.getInt(o + i * 4));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.getInt(o + i * 4));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3320,15 +3319,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         IntSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.putInt(o + i * 4, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.putInt(o + i * 4, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3172,7 +3173,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     LongVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         LongSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3222,7 +3223,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         LongSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3172,15 +3172,14 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     LongVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         LongSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.getLong(o + i * 8));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.getLong(o + i * 8));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3223,15 +3222,14 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         LongSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.putLong(o + i * 8, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.putLong(o + i * 8, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -3549,7 +3550,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     ShortVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         ShortSpecies vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -3599,7 +3600,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         ShortSpecies vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3549,15 +3549,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     ShortVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         ShortSpecies vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.getShort(o + i * 2));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.getShort(o + i * 2));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -3600,15 +3599,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         ShortSpecies vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.putShort(o + i * 2, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.putShort(o + i * 2, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -24,33 +24,11 @@
  */
 package jdk.incubator.vector;
 
-import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /*non-public*/ class VectorIntrinsics {
-    static final Unsafe U = Unsafe.getUnsafe();
-
-    static final long BUFFER_ADDRESS
-            = U.objectFieldOffset(Buffer.class, "address");
-
-    // Buffer.limit
-    static final long BUFFER_LIMIT
-            = U.objectFieldOffset(Buffer.class, "limit");
-
-    // ByteBuffer.hb
-    static final long BYTE_BUFFER_HB
-            = U.objectFieldOffset(ByteBuffer.class, "hb");
-
-    // ByteBuffer.isReadOnly
-    static final long BYTE_BUFFER_IS_READ_ONLY
-            = U.objectFieldOffset(ByteBuffer.class, "isReadOnly");
-
-    /* ============================================================================ */
-
     static final int VECTOR_ACCESS_OOB_CHECK = Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2);
 
     @ForceInline
@@ -132,19 +110,5 @@ import java.util.Objects;
         } else {
             return Math.floorMod(index, Math.abs(size));
         }
-    }
-
-    /* ============================================================================ */
-
-    /*package-private*/
-    @ForceInline
-    static Object bufferBase(ByteBuffer bb) {
-        return U.getReference(bb, BYTE_BUFFER_HB);
-    }
-
-    /*package-private*/
-    @ForceInline
-    static long bufferAddress(ByteBuffer bb, long offset) {
-        return U.getLong(bb, BUFFER_ADDRESS) + offset;
     }
 }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4517,15 +4517,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ fromByteBuffer0Template(ByteBuffer bb, int offset) {
         $Type$Species vsp = vspecies();
-        return VectorSupport.load(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            bb, offset, vsp,
-            (buf, off, s) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                return s.ldOp(wb, off,
-                        (wb_, o, i) -> wb_.get{#if[byte]?(:$Type$(}o + i * $sizeInBytes$));
-           });
+        return VectorSupport.loadFromByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                bb, offset, vsp,
+                (buf, off, s) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    return s.ldOp(wb, off,
+                            (wb_, o, i) -> wb_.get{#if[byte]?(:$Type$(}o + i * $sizeInBytes$));
+                });
     }
 
     // Unchecked storing operations in native byte order.
@@ -4568,15 +4567,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         $Type$Species vsp = vspecies();
-        VectorSupport.store(
-            vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            bufferBase(bb), bufferAddress(bb, offset),
-            this, bb, offset,
-            (buf, off, v) -> {
-                ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                v.stOp(wb, off,
-                        (wb_, o, i, e) -> wb_.put{#if[byte]?(:$Type$(}o + i * $sizeInBytes$, e));
-            });
+        VectorSupport.storeIntoByteBuffer(
+                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                this, bb, offset,
+                (buf, off, v) -> {
+                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                    v.stOp(wb, off,
+                            (wb_, o, i, e) -> wb_.put{#if[byte]?(:$Type$(}o + i * $sizeInBytes$, e));
+                });
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -33,6 +33,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -4517,7 +4518,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ fromByteBuffer0Template(ByteBuffer bb, int offset) {
         $Type$Species vsp = vspecies();
-        return VectorSupport.loadFromByteBuffer(
+        return ScopedMemoryAccess.loadFromByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 bb, offset, vsp,
                 (buf, off, s) -> {
@@ -4567,7 +4568,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
         $Type$Species vsp = vspecies();
-        VectorSupport.storeIntoByteBuffer(
+        ScopedMemoryAccess.storeIntoByteBuffer(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this, bb, offset,
                 (buf, off, v) -> {

--- a/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntFunction;
+
+public class AbstractVectorLoadStoreTest extends AbstractVectorTest {
+
+    static final Collection<ByteOrder> BYTE_ORDER_VALUES = Set.of(
+            ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN);
+
+    static final List<IntFunction<ByteBuffer>> BYTE_BUFFER_GENERATORS = List.of(
+            withToString("HB:RW:NE", (int s) -> {
+                return ByteBuffer.allocate(s)
+                        .order(ByteOrder.nativeOrder());
+            }),
+            withToString("DB:RW:NE", (int s) -> {
+                return ByteBuffer.allocateDirect(s)
+                        .order(ByteOrder.nativeOrder());
+            }),
+            withToString("MS:RW:NE", (int s) -> {
+                return MemorySegment.allocateNative(s, ResourceScope.newImplicitScope())
+                        .asByteBuffer()
+                        .order(ByteOrder.nativeOrder());
+            })
+    );
+}

--- a/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
@@ -35,8 +35,6 @@ import java.util.function.IntUnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ResourceScope;
 import org.testng.Assert;
 
 public class AbstractVectorTest {
@@ -85,25 +83,6 @@ public class AbstractVectorTest {
             }
         };
     }
-
-    static final Collection<ByteOrder> BYTE_ORDER_VALUES = Set.of(
-            ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN);
-
-    static final List<IntFunction<ByteBuffer>> BYTE_BUFFER_GENERATORS = List.of(
-            withToString("HB:RW:NE", (int s) -> {
-                return ByteBuffer.allocate(s)
-                        .order(ByteOrder.nativeOrder());
-            }),
-            withToString("DB:RW:NE", (int s) -> {
-                return ByteBuffer.allocateDirect(s)
-                        .order(ByteOrder.nativeOrder());
-            }),
-            withToString("MS:RW:NE", (int s) -> {
-                return MemorySegment.allocateNative(s, ResourceScope.newImplicitScope())
-                        .asByteBuffer()
-                        .order(ByteOrder.nativeOrder());
-            })
-    );
 
     static final List<IntFunction<boolean[]>> BOOL_ARRAY_GENERATORS = List.of(
             withToString("boolean[i % 2]", (int s) -> {

--- a/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
@@ -35,6 +35,8 @@ import java.util.function.IntUnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import org.testng.Assert;
 
 public class AbstractVectorTest {
@@ -94,6 +96,11 @@ public class AbstractVectorTest {
             }),
             withToString("DB:RW:NE", (int s) -> {
                 return ByteBuffer.allocateDirect(s)
+                        .order(ByteOrder.nativeOrder());
+            }),
+            withToString("MS:RW:NE", (int s) -> {
+                return MemorySegment.allocateNative(s, ResourceScope.newImplicitScope())
+                        .asByteBuffer()
                         .order(ByteOrder.nativeOrder());
             })
     );

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte128VectorLoadStoreTests
  *
  */
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
+public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
+public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte256VectorLoadStoreTests
  *
  */
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
+public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte512VectorLoadStoreTests
  *
  */
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte64VectorLoadStoreTests
  *
  */
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
+public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation ByteMaxVectorLoadStoreTests
  *
@@ -46,7 +46,6 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double128VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Double128VectorLoadStoreTests extends AbstractVectorTest {
+public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double256VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Double256VectorLoadStoreTests extends AbstractVectorTest {
+public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double512VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Double512VectorLoadStoreTests extends AbstractVectorTest {
+public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Double64VectorLoadStoreTests extends AbstractVectorTest {
+public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double64VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation DoubleMaxVectorLoadStoreTests
  *
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float128VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Float128VectorLoadStoreTests extends AbstractVectorTest {
+public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float256VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Float256VectorLoadStoreTests extends AbstractVectorTest {
+public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Float512VectorLoadStoreTests extends AbstractVectorTest {
+public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float512VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Float64VectorLoadStoreTests extends AbstractVectorTest {
+public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float64VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation FloatMaxVectorLoadStoreTests
  *
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int128VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Int128VectorLoadStoreTests extends AbstractVectorTest {
+public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Int256VectorLoadStoreTests extends AbstractVectorTest {
+public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int256VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int512VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Int512VectorLoadStoreTests extends AbstractVectorTest {
+public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int64VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Int64VectorLoadStoreTests extends AbstractVectorTest {
+public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation IntMaxVectorLoadStoreTests
  *
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long128VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Long128VectorLoadStoreTests extends AbstractVectorTest {
+public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long256VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Long256VectorLoadStoreTests extends AbstractVectorTest {
+public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Long512VectorLoadStoreTests extends AbstractVectorTest {
+public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long512VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long64VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Long64VectorLoadStoreTests extends AbstractVectorTest {
+public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation LongMaxVectorLoadStoreTests
  *
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Short128VectorLoadStoreTests extends AbstractVectorTest {
+public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_128;
 

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short128VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short256VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Short256VectorLoadStoreTests extends AbstractVectorTest {
+public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_256;
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Short512VectorLoadStoreTests extends AbstractVectorTest {
+public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_512;
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short512VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short64VectorLoadStoreTests
  *
  */
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class Short64VectorLoadStoreTests extends AbstractVectorTest {
+public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_64;
 

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
+public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_MAX;
 

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation ShortMaxVectorLoadStoreTests
  *
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -61,7 +61,7 @@ import java.util.List;
 import java.util.function.*;
 
 @Test
-public class $vectorteststype$ extends AbstractVectorTest {
+public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 #if[MaxBit]
     static final VectorSpecies<$Wideboxtype$> SPECIES =
                 $Type$Vector.SPECIES_MAX;

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
+ * @modules jdk.incubator.foreign jdk.incubator.vector java.base/jdk.internal.vm.annotation
 #if[MaxBit]
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation $vectorteststype$
@@ -57,7 +57,6 @@ import java.nio.$Type$Buffer;
 #end[!byte]
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 


### PR DESCRIPTION
The Foreign Memory API supports viewing a `MemorySegment` as a `ByteBuffer`, an instance of which can then be passed to the vector load/store access methods.

Such `ByteBuffer` access requires accesses are scoped (a method annotated with `ScopedMemoryAccess.Scoped`) and the `ByteBuffer`'s scope (instance of `ScopedMemoryAccess.Scope`) checked for validity. Thereby ensuring exceptional failure if the underlying segment is shared and is closed. 

All Vector tests pass on linux-x64, linux-aarch64, macosx-x64, and windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269246](https://bugs.openjdk.java.net/browse/JDK-8269246): Scoped ByteBuffer vector access


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/129.diff">https://git.openjdk.java.net/jdk17/pull/129.diff</a>

</details>
