### PR TITLE
8267952: async logging supports to dynamically change tags and decorators

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -186,7 +186,7 @@ AsyncLogWriter* AsyncLogWriter::instance() {
 
 // Inserts a flush token into the async output buffer and waits until the AsyncLog thread
 // signals that it has seen it and completed all dequeued message processing.
-// This is method is not MT-safe in itself, but is guarded by another lock in the usual
+// This method is not MT-safe in itself, but is guarded by another lock in the usual
 // usecase - see the comments in the header file for more details.
 void AsyncLogWriter::flush() {
   if (_instance != nullptr) {

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -41,7 +41,7 @@ class AsyncLogWriter::AsyncLogLocker : public StackObj {
 };
 
 void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
-  if (_buffer.size() >= _buffer_max_size)  {
+  if (_buffer.size() >= _buffer_max_size) {
     bool p_created;
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
@@ -50,13 +50,12 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     return;
   }
 
-  assert(_buffer.size() < _buffer_max_size, "_buffer is over-sized.");
   _buffer.push_back(msg);
   _sem.signal();
 }
 
 void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg) {
-  AsyncLogMessage m(output, decorations, os::strdup(msg));
+  AsyncLogMessage m(&output, decorations, os::strdup(msg));
 
   { // critical area
     AsyncLogLocker locker;
@@ -70,13 +69,13 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator m
   AsyncLogLocker locker;
 
   for (; !msg_iterator.is_at_end(); msg_iterator++) {
-    AsyncLogMessage m(output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
+    AsyncLogMessage m(&output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
     enqueue_locked(m);
   }
 }
 
 AsyncLogWriter::AsyncLogWriter()
-  : _lock(1), _sem(0), _io_sem(1),
+  : _lock(1), _sem(0), _flush_sem(0),
     _initialized(false),
     _stats(17 /*table_size*/) {
   if (os::create_thread(this, os::asynclog_thread)) {
@@ -98,10 +97,10 @@ class AsyncLogMapIterator {
     using none = LogTagSetMapping<LogTag::__NO_TAG>;
 
     if (*counter > 0) {
-      LogDecorations decorations(LogLevel::Warning, none::tagset(), output->decorators());
+      LogDecorations decorations(LogLevel::Warning, none::tagset(), LogDecorators::All);
       stringStream ss;
       ss.print(UINT32_FORMAT_W(6) " messages dropped due to async logging", *counter);
-      AsyncLogMessage msg(*output, decorations, ss.as_string(true /*c_heap*/));
+      AsyncLogMessage msg(output, decorations, ss.as_string(true /*c_heap*/));
       _logs.push_back(msg);
       *counter = 0;
     }
@@ -118,7 +117,6 @@ void AsyncLogWriter::write() {
   // The operation 'pop_all()' is done in O(1). All I/O jobs are then performed without
   // lock protection. This guarantees I/O jobs don't block logsites.
   AsyncLogBuffer logs;
-  bool own_io = false;
 
   { // critical region
     AsyncLogLocker locker;
@@ -127,14 +125,11 @@ void AsyncLogWriter::write() {
     // append meta-messages of dropped counters
     AsyncLogMapIterator dropped_counters_iter(logs);
     _stats.iterate(&dropped_counters_iter);
-    own_io = _io_sem.trywait();
   }
 
   LinkedListIterator<AsyncLogMessage> it(logs.head());
-  if (!own_io) {
-    _io_sem.wait();
-  }
 
+  int req = 0;
   while (!it.is_empty()) {
     AsyncLogMessage* e = it.next();
     char* msg = e->message();
@@ -142,9 +137,17 @@ void AsyncLogWriter::write() {
     if (msg != nullptr) {
       e->output()->write_blocking(e->decorations(), msg);
       os::free(msg);
+    } else if (e->output() == nullptr) {
+      // encounter a flush token. take a record for the time being
+      // and notify flush() after the loop.
+      req++;
     }
   }
-  _io_sem.signal();
+
+  if (req > 0) {
+    assert(req == 1, "AsyncLogWriter::flush() is NOT MT-safe!");
+    _flush_sem.signal(req);
+  }
 }
 
 void AsyncLogWriter::run() {
@@ -181,10 +184,20 @@ AsyncLogWriter* AsyncLogWriter::instance() {
   return _instance;
 }
 
-// write() acquires and releases _io_sem even _buffer is empty.
-// This guarantees all logging I/O of dequeued messages are done when it returns.
+// NOT MT-safe! see the comments in the header file.
 void AsyncLogWriter::flush() {
   if (_instance != nullptr) {
-    _instance->write();
+    {
+      using none = LogTagSetMapping<LogTag::__NO_TAG>;
+      AsyncLogLocker locker;
+      LogDecorations d(LogLevel::Off, none::tagset(), LogDecorators::None);
+      AsyncLogMessage token(nullptr, d, nullptr);
+
+      // not disposable
+      _instance->_buffer.push_back(token);
+      _instance->_sem.signal();
+    }
+
+    _instance->_flush_sem.wait();
   }
 }

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -121,16 +121,16 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // initialize() is called once when JVM is initialized. It creates and initializes the singleton instance of AsyncLogWriter.
 // Once async logging is established, there's no way to turn it off.
 //
-// instance() is MT-safe and returns the pointer of the singleton instance if and only if async logging is enabled and has well
-// initialized. Clients can use its return value to determine async logging is established or not.
+// instance() is MT-safe and returns the pointer of the singleton instance if and only if async logging is enabled and has
+// successfully initialized. Clients can use its return value to determine async logging is established or not.
 //
-// enqueue() is the basic operation of AsyncLogWriter. 2 overloading versions of it are provided to match LogOutput::write().
+// enqueue() is the basic operation of AsyncLogWriter. Two overloading versions of it are provided to match LogOutput::write().
 // They are both MT-safe and non-blocking. Derived classes of LogOutput can invoke the corresponding enqueue() in write() and
 // return 0. AsyncLogWriter is responsible of copying neccessary data.
 //
-// flush() is designated to flush out all pending messages. MT-safety is not provided. It is no-op if async logging is not in use.
-// In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). When the users change logging configurations
-// via jcmd, LogConfiguration::configure_output() invokes it with the protection of ConfigurationLock.
+// flush() is designated to flush out all pending messages before returning. MT-safety is not provided. It is no-op if async
+// logging is not in use. In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). When the users change
+// logging configurations via jcmd, LogConfiguration::configure_output() invokes it with the protection of ConfigurationLock.
 class AsyncLogWriter : public NonJavaThread {
   class AsyncLogLocker;
 

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -91,18 +91,18 @@ class LinkedListDeque : private LinkedListImpl<E, ResourceObj::C_HEAP, F> {
 };
 
 class AsyncLogMessage {
-  LogFileOutput& _output;
+  LogFileOutput* _output;
   const LogDecorations _decorations;
   char* _message;
 
 public:
-  AsyncLogMessage(LogFileOutput& output, const LogDecorations& decorations, char* msg)
+  AsyncLogMessage(LogFileOutput* output, const LogDecorations& decorations, char* msg)
     : _output(output), _decorations(decorations), _message(msg) {}
 
   // placeholder for LinkedListImpl.
   bool equals(const AsyncLogMessage& o) const { return false; }
 
-  LogFileOutput* output() const { return &_output; }
+  LogFileOutput* output() const { return _output; }
   const LogDecorations& decorations() const { return _decorations; }
   char* message() const { return _message; }
 };
@@ -124,14 +124,13 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // instance() is MT-safe and returns the pointer of the singleton instance if and only if async logging is enabled and has well
 // initialized. Clients can use its return value to determine async logging is established or not.
 //
-// The basic operation of AsyncLogWriter is enqueue(). 2 overloading versions of it are provided to match LogOutput::write().
+// enqueue() is the basic operation of AsyncLogWriter. 2 overloading versions of it are provided to match LogOutput::write().
 // They are both MT-safe and non-blocking. Derived classes of LogOutput can invoke the corresponding enqueue() in write() and
 // return 0. AsyncLogWriter is responsible of copying neccessary data.
 //
-// The static member function flush() is designated to flush out all pending messages when JVM is terminating.
-// In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). flush() is MT-safe and can be invoked arbitrary
-// times. It is no-op if async logging is not established.
-//
+// flush() is designated to flush out all pending messages. MT-safety is not provided. It is no-op if async logging is not in use.
+// In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). When the users change logging configurations
+// via jcmd, LogConfiguration::configure_output() invokes it with the protection of ConfigurationLock.
 class AsyncLogWriter : public NonJavaThread {
   class AsyncLogLocker;
 
@@ -141,8 +140,7 @@ class AsyncLogWriter : public NonJavaThread {
   // _sem is a semaphore whose value denotes how many messages have been enqueued.
   // It decreases in AsyncLogWriter::run()
   Semaphore _sem;
-  // A lock of IO
-  Semaphore _io_sem;
+  Semaphore _flush_sem;
 
   volatile bool _initialized;
   AsyncLogMap _stats; // statistics for dropped messages

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -128,9 +128,9 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // They are both MT-safe and non-blocking. Derived classes of LogOutput can invoke the corresponding enqueue() in write() and
 // return 0. AsyncLogWriter is responsible of copying neccessary data.
 //
-// flush() is designated to flush out all pending messages before returning. MT-safety is not provided. It is no-op if async
-// logging is not in use. In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). When the users change
-// logging configurations via jcmd, LogConfiguration::configure_output() invokes it with the protection of ConfigurationLock.
+// flush() ensures that all pending messages have been written out before it returns. It is not MT-safe in itself. When users
+// change the logging configuration via jcmd, LogConfiguration::configure_output() calls flush() under the protection of the
+// ConfigurationLock. In addition flush() is called during JVM termination, via LogConfiguration::finalize.
 class AsyncLogWriter : public NonJavaThread {
   class AsyncLogLocker;
 

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -211,6 +211,21 @@ void LogConfiguration::delete_output(size_t idx) {
   delete output;
 }
 
+// MT-SAFETY
+//
+// ConfigurationLock can guarantee that only one thread is performing reconfiguration. This function still needs
+// to be MT-safe because logsites in other threads may be executing in parallel. Reconfiguration means unified
+// logging allows users to dynamically change tags and decorators of a log output via DCMD(logDiagnosticCommand.hpp).
+//
+// A RCU-style synchronization 'wait_until_no_readers()' is imposed inside of 'ts->set_output_level(output, level)'
+// if setting has changed. It guarantees that all logs either synchronous writing or enqueuing to the async buffer
+// see the new tags and decorators. It's worth noting that the synchronization happens even level does not change.
+//
+// LogDecorator is a set of decorators represented in a uint. ts->update_decorators(decorators) is a union of the
+// current decorators and new_decorators. It's safe to do output->set_decorators(decorators) because new_decorators
+// is a subset of relevant tagsets decorators. After updating output's decorators, it is still safe to shrink all
+// decorators of tagsets.
+//
 void LogConfiguration::configure_output(size_t idx, const LogSelectionList& selections, const LogDecorators& decorators) {
   assert(ConfigurationLock::current_thread_has_lock(), "Must hold configuration lock to call this function.");
   assert(idx < _n_outputs, "Invalid index, idx = " SIZE_FORMAT " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
@@ -253,6 +268,15 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
     on_level[level]++;
   }
 
+  // for async logging, enqueuing instead of writing is still under protection of the synchronization
+  // `wait_until_no_readers()`. There are 2 hazards in async logging as follows.
+  //  1. asynclog buffer may be holding some log messages with previous decorators.
+  //  2. asynclog buffer may be holding some log messages targeting to the output 'idx'.
+  //
+  // A flush operation guarantees to all pending messages in buffer are written before returning. Therefore,
+  // the two hazards won't appear after it. It's a nop if async logging is not set.
+  AsyncLogWriter::flush();
+
   // It is now safe to set the new decorators for the actual output
   output->set_decorators(decorators);
 
@@ -262,10 +286,6 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   }
 
   if (!enabled && idx > 1) {
-    // User may disable a logOuput like this:
-    // LogConfiguration::parse_log_arguments(filename, "all=off", "", "", &stream);
-    // Just be conservative. Flush them all before deleting idx.
-    AsyncLogWriter::flush();
     // Output is unused and should be removed, unless it is stdout/stderr (idx < 2)
     delete_output(idx);
     return;

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -269,7 +269,7 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   }
 
   // For async logging we have to ensure that all enqueued messages, which may refer to previous decorators,
-  // or a soon-to-be-deleted outputs, are written out first. The flush() call ensures this.
+  // or a soon-to-be-deleted output, are written out first. The flush() call ensures this.
   AsyncLogWriter::flush();
 
   // It is now safe to set the new decorators for the actual output

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -25,7 +25,19 @@
 #include "logging/logDecorators.hpp"
 #include "runtime/os.hpp"
 
+template <LogDecorators::Decorator d>
+struct AllBitmask {
+  // Use recursive template deduction to calculate the bitmask of all decorations.
+  static const uint _value = (1 << d) | AllBitmask<static_cast<LogDecorators::Decorator>(d + 1)>::_value;
+};
+
+template<>
+struct AllBitmask<LogDecorators::Count> {
+  static const uint _value = 0;
+};
+
 const LogDecorators LogDecorators::None = LogDecorators(0);
+const LogDecorators LogDecorators::All  = LogDecorators(AllBitmask<time_decorator>::_value);
 
 const char* LogDecorators::_name[][2] = {
 #define DECORATOR(n, a) {#n, #a},

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -82,6 +82,7 @@ class LogDecorators {
 
  public:
   static const LogDecorators None;
+  static const LogDecorators All;
 
   LogDecorators() : _decorators(DefaultDecoratorsMask) {
   }

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -46,7 +46,6 @@ LogTestFixture::LogTestFixture() : _n_snapshots(0), _configuration_snapshot(NULL
 }
 
 LogTestFixture::~LogTestFixture() {
-  AsyncLogWriter::flush();
   restore_config();
   clear_snapshot();
   delete_file(TestLogFileName);

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,6 +207,13 @@ TEST(LogDecorators, none) {
   LogDecorators dec = LogDecorators::None;
   for (size_t i = 0; i < LogDecorators::Count; i++) {
     EXPECT_FALSE(dec.is_decorator(decorator_array[i]));
+  }
+}
+
+TEST(LogDecorators, all) {
+  LogDecorators dec = LogDecorators::All;
+  for (size_t i = 0; i < LogDecorators::Count; i++) {
+    EXPECT_TRUE(dec.is_decorator(decorator_array[i]));
   }
 }
 


### PR DESCRIPTION
This patch fixed intermittent crashes of gtest/AsyncLogGtest.java. The root cause 
is that previous flush() can't guarantee flush all pending messages in AsyncLog
buffer. This patch implements flush() using a synchronizaton token and waits for
completion. This approach isn't MT-safe but it can serialize all flush() calls in
a thread. 

Two concurrent tests are appended to cover the hazard cases.
This patch also comments LogConfiguration::configure_output() MT-safety.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267952](https://bugs.openjdk.java.net/browse/JDK-8267952): async logging supports to dynamically change tags and decorators


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/130.diff">https://git.openjdk.java.net/jdk17/pull/130.diff</a>

</details>
