### PR TITLE
8269265: ProblemList serviceability/sa/TestJmapCoreMetaspace.java with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -39,7 +39,7 @@ serviceability/sa/ClhsdbFindPC.java#id3                       8268722   macosx-x
 serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x64
 serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
 serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
-serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   macosx-x64,linux-x64
+serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   generic-all
 
 serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
 serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x64


### PR DESCRIPTION
In order to reduce the noise in the JDK17 CI, I'm ProblemListing
serviceability/sa/TestJmapCoreMetaspace.java with ZGC.

It has been already added for macosx-x64 and for linux-x64, but we saw same problem on Windows. So we need to add it for all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269265](https://bugs.openjdk.java.net/browse/JDK-8269265): ProblemList serviceability/sa/TestJmapCoreMetaspace.java with ZGC


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/131.diff">https://git.openjdk.java.net/jdk17/pull/131.diff</a>

</details>
