### PR TITLE
8269126: Rename G1AllowPreventiveGC option to G1UsePreventiveGC

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1414,7 +1414,7 @@ static size_t get_num_regions_adjust_for_plab_waste(size_t byte_count) {
 }
 
 bool G1Policy::preventive_collection_required(uint alloc_region_count) {
-  if (!G1AllowPreventiveGC || !Universe::is_fully_initialized()) {
+  if (!G1UsePreventiveGC || !Universe::is_fully_initialized()) {
     // Don't attempt any preventive GC's if the feature is disabled,
     // or before initialization is complete.
     return false;

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -309,7 +309,7 @@
           "disables this check.")                                           \
           range(0.0, (double)max_uintx)                                     \
                                                                             \
-  product(bool, G1AllowPreventiveGC, true, DIAGNOSTIC,                       \
+  product(bool, G1UsePreventiveGC, true, DIAGNOSTIC,                        \
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -242,7 +242,7 @@ public class TestGCLogMessages {
                                                                   "-XX:G1EvacuationFailureALotCount=100",
                                                                   "-XX:G1EvacuationFailureALotInterval=1",
                                                                   "-XX:+UnlockDiagnosticVMOptions",
-                                                                  "-XX:-G1AllowPreventiveGC",
+                                                                  "-XX:-G1UsePreventiveGC",
                                                                   "-Xlog:gc+phases=debug",
                                                                   GCTestWithEvacuationFailure.class.getName());
 
@@ -255,7 +255,7 @@ public class TestGCLogMessages {
                                                    "-Xmn16M",
                                                    "-Xms32M",
                                                    "-XX:+UnlockDiagnosticVMOptions",
-                                                   "-XX:-G1AllowPreventiveGC",
+                                                   "-XX:-G1UsePreventiveGC",
                                                    "-Xlog:gc+phases=trace",
                                                    GCTestWithEvacuationFailure.class.getName());
 


### PR DESCRIPTION
Hi all,

can I have reviews for this change that as the title suggest only changes the name of the `G1AllowPreventiveGC` option to `G1UsePreventiveGC` to better conform to other G1 options which all use `Use` as prefix (jdk17 version).

Since this is a diagnostic flag, no further process is required.

Testing: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269126](https://bugs.openjdk.java.net/browse/JDK-8269126): Rename G1AllowPreventiveGC option to G1UsePreventiveGC


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/132.diff">https://git.openjdk.java.net/jdk17/pull/132.diff</a>

</details>
