### PR TITLE
8269088: C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -950,7 +950,7 @@ void PhaseIdealLoop::try_move_store_after_loop(Node* n) {
             }
 #endif
             lca = place_outside_loop(lca, n_loop);
-            assert(!n_loop->is_member(get_loop(lca)), "control must not be back in of loop");
+            assert(!n_loop->is_member(get_loop(lca)), "control must not be back in the loop");
             assert(get_loop(lca)->_nest < n_loop->_nest || lca->in(0)->Opcode() == Op_NeverBranch, "must not be moved into inner loop");
 
             // Move store out of the loop

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -949,6 +949,9 @@ void PhaseIdealLoop::try_move_store_after_loop(Node* n) {
               assert(get_loop(lca) == outer_loop, "safepoint in outer loop consume all memory state");
             }
 #endif
+            lca = place_outside_loop(lca, n_loop);
+            assert(!n_loop->is_member(get_loop(lca)), "control must not be back in of loop");
+            assert(get_loop(lca)->_nest < n_loop->_nest || lca->in(0)->Opcode() == Op_NeverBranch, "must not be moved into inner loop");
 
             // Move store out of the loop
             _igvn.replace_node(hook, n->in(MemNode::Memory));
@@ -1147,7 +1150,9 @@ Node* PhaseIdealLoop::place_outside_loop(Node* useblock, IdealLoopTree* loop) co
   // Pick control right outside the loop
   for (;;) {
     Node* dom = idom(useblock);
-    if (loop->is_member(get_loop(dom))) {
+    if (loop->is_member(get_loop(dom)) ||
+        // NeverBranch nodes are not assigned to the loop when constructed
+        (dom->Opcode() == Op_NeverBranch && loop->is_member(get_loop(dom->in(0))))) {
       break;
     }
     useblock = dom;

--- a/test/hotspot/jtreg/compiler/loopopts/TestStoreSunkInInnerLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStoreSunkInInnerLoop.java
@@ -70,7 +70,7 @@ public class TestStoreSunkInInnerLoop {
             }
         } while (++i13 < 247);
     }
-    
+
     public static void main(String[] strArr) {
         TestStoreSunkInInnerLoop _instance = new TestStoreSunkInInnerLoop();
         for (int i = 0; i < 10; i++ ) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestStoreSunkInInnerLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStoreSunkInInnerLoop.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8269088
+ * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
+ *
+ * @requires vm.gc.Serial
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestStoreSunkInInnerLoop -XX:CompileCommand=quiet -XX:+UseSerialGC -Xmx256m TestStoreSunkInInnerLoop
+ *
+ */
+
+public class TestStoreSunkInInnerLoop {
+
+    public static final int N = 400;
+
+    public static int iFld=-10622;
+    public static long lArrFld[]=new long[N];
+    public float fArrFld[][]=new float[N][N];
+
+    public void mainTest() {
+
+        int i8=-10584, i10=37284, i11=38, i13=-238, i14=-18473, i15=-53564;
+        boolean b1=false;
+
+        TestStoreSunkInInnerLoop.iFld -= TestStoreSunkInInnerLoop.iFld;
+        for (i8 = 224; i8 > 7; i8 -= 2) {
+            i10 = 1;
+            while (++i10 < 232) {
+                TestStoreSunkInInnerLoop.iFld += i8;
+            }
+            for (i11 = 8; i11 < 232; ++i11) {
+                if (b1) continue;
+                TestStoreSunkInInnerLoop.lArrFld[i11] += i10;
+            }
+        }
+        i13 = 1;
+        do {
+            switch ((i13 % 2) + 126) {
+            case 126:
+                for (i14 = 102; i14 > 2; i14 -= 3) {
+                    fArrFld[i13][(-126 >>> 1) % N] -= i15;
+                }
+                break;
+            case 127:
+                i15 = (i13 % i10);
+                break;
+            default:
+            }
+        } while (++i13 < 247);
+    }
+    
+    public static void main(String[] strArr) {
+        TestStoreSunkInInnerLoop _instance = new TestStoreSunkInInnerLoop();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.mainTest();
+        }
+    }
+}


### PR DESCRIPTION
In PhaseIdealLoop::try_sink_out_of_loop(), a Store is not expected to
be a candidate for sinking: if a Store is in a loop, there has to be
at least a memory Phi keeping the Store in the loop. In the case of
the failure, a Store has control set in a loop but the Store is not
connected to a loop memory Phi. The reason for that is that the Store
was moved out of loop by PhaseIdealLoop::try_move_store_after_loop()
which moved the Store to the lca of its uses (other than the loop
Phi), in this case another loop.

It doesn't look right that a Store is removed from a loop only to be
added to another one so I propose fixing that by placing the Store
right out of the loop it's being moved out of (similar to
PhaseIdealLoop::try_sink_out_of_loop()) rather than at the lca of
uses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269088](https://bugs.openjdk.java.net/browse/JDK-8269088): C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to dcb1e6467a539aee184d751717a0a0bdf0f3a541
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to dcb1e6467a539aee184d751717a0a0bdf0f3a541
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/133.diff">https://git.openjdk.java.net/jdk17/pull/133.diff</a>

</details>
