### PR TITLE
8269141: Switch statement containing pattern case label element gets in the loop during execution

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1375,8 +1375,7 @@ public class Gen extends JCTree.Visitor {
 
             if (switchEnv.info.cont != null) {
                 Assert.check(patternSwitch);
-                code.resolve(switchEnv.info.cont);
-                code.resolve(code.branch(goto_), switchStart);
+                code.resolve(switchEnv.info.cont, switchStart);
             }
 
             // Resolve all breaks.

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333
+ * @bug 8262891 8268333 8268896
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -60,6 +60,8 @@ public class Switches {
         runEnumTest(this::testIntegerWithGuardsExpression1);
         runStringWithConstant(this::testStringWithConstant);
         runStringWithConstant(this::testStringWithConstantExpression);
+        runFallThrough(this::testFallThroughStatement);
+        runFallThrough(this::testFallThroughExpression);
         npeTest(this::npeTestStatement);
         npeTest(this::npeTestExpression);
         exhaustiveStatementSane("");
@@ -102,6 +104,10 @@ public class Switches {
         assertEquals(2, mapper.apply("AA"));
         assertEquals(0, mapper.apply(""));
         assertEquals(-1, mapper.apply(null));
+    }
+
+    void runFallThrough(Function<Integer, Integer> mapper) {
+        assertEquals(2, mapper.apply(1));
     }
 
     void npeTest(Consumer<I> testCase) {
@@ -307,6 +313,31 @@ public class Switches {
             case 2 -> "broken";
             case null, Integer x -> String.valueOf(x);
         };
+    }
+
+    Integer testFallThroughStatement(Integer i) {
+        int r = 0;
+
+        switch (i) {
+            case Integer o && o != null:
+                r = 1;
+            default:
+                r = 2;
+        }
+
+        return r;
+    }
+
+    Integer testFallThroughExpression(Integer i) {
+        int r = switch (i) {
+            case Integer o && o != null:
+                r = 1;
+            default:
+                r = 2;
+                yield r;
+        };
+
+        return r;
     }
 
     void npeTestStatement(I i) {


### PR DESCRIPTION
Guards in the pattern matching switches are implemented internally through `continue` in switches (which cannot be written in the source, but can be used internally). Consider code:
```
switch (...) {
     case String s && s.isEmpty(): break;
     default: //fall through outside the switch
}
```
The current implementation in Gen will: `code.resolve(switchEnv.info.cont);` which puts (merges) the code paths for the `continue`s to `pendingJumps`. The `code.branch(goto_)` in `code.resolve(code.branch(goto_), switchStart)` will merge the `pendingJumps` (i.e. the continues) with the execution as it falls through the default case of the switch, and the `code.resolve` will jump for all the merged code paths to the beginning of the switch. This is wrong - we should only jump to the beginning of the switch for the `continue` code paths, not for the final fall-through code path. This is what the fix is trying to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269141](https://bugs.openjdk.java.net/browse/JDK-8269141): Switch statement containing pattern case label element gets in the loop during execution


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/135.diff">https://git.openjdk.java.net/jdk17/pull/135.diff</a>

</details>
