### PR TITLE
8269314: ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Win-X64 and linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -110,7 +110,7 @@ resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8262386 generic-al
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatIntervalTest.java 8214032 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java 8224150 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
-serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-x64
+serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 serviceability/jvmti/CompiledMethodLoad/Zombie.java 8245877 linux-aarch64
 
 #############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Win-X64 and linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269314](https://bugs.openjdk.java.net/browse/JDK-8269314): ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Win-X64 and linux-aarch64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/138.diff">https://git.openjdk.java.net/jdk17/pull/138.diff</a>

</details>
