### PR TITLE
8269315: ProblemList javax/swing/JFileChooser/FileSystemView/SystemIconTest.java on Win-X64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,6 +742,7 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
+javax/swing/JFileChooser/FileSystemView/SystemIconTest.java 8268280 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JFileChooser/FileSystemView/SystemIconTest.java on Win-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269315](https://bugs.openjdk.java.net/browse/JDK-8269315): ProblemList javax/swing/JFileChooser/FileSystemView/SystemIconTest.java on Win-X64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/139.diff">https://git.openjdk.java.net/jdk17/pull/139.diff</a>

</details>
