### PR TITLE
8260684: vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -127,7 +127,7 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
         private void eatMemory(int initialFactor) {
             GarbageUtils.eatMemory(getExecutionController(),
                                    garbageProducer,
-                                   initialFactor , 10, 0);
+                                   initialFactor, 10, 0);
         }
 
         public void run() {

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@
 package gc.gctests.PhantomReference.phantom001;
 
 import java.lang.ref.*;
+import java.time.LocalTime;
 import nsk.share.gc.*;
 import nsk.share.gc.gp.*;
 import nsk.share.gc.gp.string.InternedStringProducer;
@@ -98,12 +99,43 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
         int iteration;
         private volatile boolean finalized;
 
+        private String addMessageContext(String message) {
+            return "T:" + Thread.currentThread().getId() +
+                " I:" + iteration +
+                " " + LocalTime.now().toString() +
+                ": " + message;
+        }
+
+        private void info(String message) {
+            log.info(addMessageContext(message));
+        }
+
+        private void progress(String message) {
+            // Uncomment this to get more verbose logging.
+            // log.debug(addMessageContext(message));
+        }
+
+        private void fail(String message) {
+            log.error(addMessageContext("[FAILED] " + message));
+            setFailed(true);
+        }
+
+        private boolean shouldTerminate() {
+            return !getExecutionController().continueExecution();
+        }
+
+        private void eatMemory(int initialFactor) {
+            GarbageUtils.eatMemory(getExecutionController(),
+                                   garbageProducer,
+                                   initialFactor , 10, 0);
+        }
+
         public void run() {
             try {
-                log.info("iteration " + iteration);
+                int code = iteration % TYPES_COUNT;
+                info("start code " + code);
                 ReferenceQueue queue = new ReferenceQueue();
                 PhantomReference reference;
-                int code = iteration % TYPES_COUNT;
                 String type;
                 // Define a specific type for each thread to test
                 switch (code) {
@@ -158,50 +190,65 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
                 }
 
                 int initialFactor = memoryStrategy.equals(MemoryStrategy.HIGH) ? 1 : (memoryStrategy.equals(MemoryStrategy.LOW) ? 10 : 2);
-                GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
+
+                // If referent is finalizable, provoke GCs and wait for finalization.
                 if (type.equals("class")) {
-                    while (!finalized && getExecutionController().continueExecution()) {
-                        System.runFinalization(); //does not guarantee finalization, but increases the chance
+                    progress("Waiting for finalization: " + type);
+                    for (int checks = 0; !finalized && !shouldTerminate(); ++checks) {
+                        // There are scenarios where one eatMemory() isn't enough,
+                        // but 10 iterations really ought to be sufficient.
+                        if (checks > 10) {
+                            fail("Waiting for finalization: " + type);
+                            return;
+                        }
+                        eatMemory(initialFactor);
+                        // Give some time for finalizer to run.
                         try {
                             Thread.sleep(100);
                         } catch (InterruptedException e) {}
-                        GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                     }
-
-                    //provoke gc once more to make finalized object phantom reachable
-                    GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                 }
-                if (!getExecutionController().continueExecution()) {
-                    // we were interrrupted by stresser. just exit...
+
+                // Provoke GCs and wait for reference to be enqueued.
+                progress("Waiting for enqueue: " + type);
+                Reference polled = queue.poll();
+                for (int checks = 0; polled == null && !shouldTerminate(); ++checks) {
+                    // There are scenarios where one eatMemory() isn't enough,
+                    // but 10 iterations really ought to be sufficient.
+                    if (checks > 10) {
+                        fail("Waiting for enqueue: " + type);
+                        return;
+                    }
+                    eatMemory(initialFactor);
+                    // Give some time for reference to be enqueued.
+                    try {
+                        polled = queue.remove(100);
+                    } catch (InterruptedException e) {}
+                }
+
+                if (polled == null && shouldTerminate()) {
+                    info("Terminated: " + type);
                     return;
                 }
-                Reference polledReference = null;
-                try {
-                    polledReference = queue.remove();
-                } catch (InterruptedException e) {
-                    log.error("Unexpected InterruptedException during queue.remove().");
-                    setFailed(true);
-                }
-                // Check the reference and the queue
+
                 // The polled reference must be equal to the one enqueued to
                 // the queue
-
-                if (polledReference != reference) {
-                    log.error("The original reference is not equal to polled reference.");
-                    setFailed(true);
+                if (polled != reference) {
+                    fail("The original reference is not equal to polled reference.");
+                    return;
                 }
 
                 // queue.poll() once again must return null now, since there is
                 // only one reference in the queue
-                polledReference = queue.poll();
-                if (polledReference != null) {
-                    log.error("There are more  than one references in the queue.");
-                    setFailed(true);
+                if (queue.poll() != null) {
+                    fail("There are more than one reference in the queue.");
+                    return;
                 }
-                reference.clear();
+                progress("Finished: " + type);
             } catch (OutOfMemoryError e) {
+            } finally {
+                iteration++;
             }
-            iteration++;
         }
 
         class Referent {

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -160,16 +160,16 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
                 int initialFactor = memoryStrategy.equals(MemoryStrategy.HIGH) ? 1 : (memoryStrategy.equals(MemoryStrategy.LOW) ? 10 : 2);
                 GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                 if (type.equals("class")) {
-                        while (!finalized && getExecutionController().continueExecution()) {
-                                System.runFinalization(); //does not guarantee finalization, but increases the chance
-                                try {
-                                        Thread.sleep(100);
-                                } catch (InterruptedException e) {}
-                                GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
-                        }
-
-                        //provoke gc once more to make finalized object phantom reachable
+                    while (!finalized && getExecutionController().continueExecution()) {
+                        System.runFinalization(); //does not guarantee finalization, but increases the chance
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {}
                         GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
+                    }
+
+                    //provoke gc once more to make finalized object phantom reachable
+                    GarbageUtils.eatMemory(getExecutionController(), garbageProducer, initialFactor , 10, 0);
                 }
                 if (!getExecutionController().continueExecution()) {
                     // we were interrrupted by stresser. just exit...
@@ -206,12 +206,12 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
 
         class Referent {
 
-                //We need discard this flag to make second and following checks with type.equals("class") useful
-                public Referent() {
-                                finalized = false;
-                        }
+            //We need discard this flag to make second and following checks with type.equals("class") useful
+            public Referent() {
+                finalized = false;
+            }
 
-                        protected void finalize() {
+            protected void finalize() {
                 finalized = true;
             }
         }


### PR DESCRIPTION
Please review this fix of
vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java to
eliminate races that can lead to the test occasionally timing out.

When the referent being tested by a particular iteration is a finalizable
class, the test invoked eatMemory() repeatedly until the referent's
finalize() function set a flag.  Then, whether the referent is finalizable
or not, there is a call to eatMemory() to cause the phantom reference to be
cleared and notified.  The testing thread then proceeds to wait for the
reference to be notified.

This has a problem with ZGC.  One collection made the referent finalizable.
Reference processing and finalization will end up ensuring it will survive
the following collection.  If the post-finalization eatMemory() is that next
collection, then it won't clear and notify the associated PhantomReference.
Usually that doesn't cause a problem because the referent will be reclaimed
by some other thread's later call to eatMemory().  But if the test is done
and terminating, there won't be a later GC, and the wait for notification
will block until the test times out.

There are other, rarer, scenarios with various collectors that could lead to
similar timeouts, but the one described above is "relatively" likely.

While investigating this issue I did a bunch of code cleanup (for example,
there was some really badly formatted code), refactoring, and commenting.
As a result, a large fraction of the test has changed, though mostly in ways
that don't affect it's function.  The first of the two commits in the PR is
a whitespace-only cleanup.  Excluding it may make reviewing easier.

Testing:
Ran the phantom002 test a couple thousand times.

Using a modified version of the test, verified that the described problem
case actually occurs, on the order of 1% of the time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260684](https://bugs.openjdk.java.net/browse/JDK-8260684): vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java timed out


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**) ⚠️ Review applies to 5238becabaed1bf2aa574d45a367cbfcd187b03a
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - Committer) ⚠️ Review applies to 5238becabaed1bf2aa574d45a367cbfcd187b03a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/142.diff">https://git.openjdk.java.net/jdk17/pull/142.diff</a>

</details>
