### PR TITLE
8269335: Unable to load svml library

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7001,17 +7001,9 @@ address generate_avx_ghash_processBlocks() {
     // Get svml stub routine addresses
     void *libsvml = NULL;
     char ebuf[1024];
-    char dll_path[JVM_MAXPATHLEN];
-#ifdef _WINDOWS
-    int ret = jio_snprintf(dll_path, sizeof(dll_path), "%s%sbin", Arguments::get_java_home(), os::file_separator());
-#else
-    int ret = jio_snprintf(dll_path, sizeof(dll_path), "%s%slib", Arguments::get_java_home(), os::file_separator());
-#endif
-    if (ret != -1) {
-      char dll_name[JVM_MAXPATHLEN];
-      if (os::dll_locate_lib(dll_name, sizeof(dll_name), dll_path, "svml")) {
-        libsvml = os::dll_load(dll_name, ebuf, sizeof ebuf);
-      }
+    char dll_name[JVM_MAXPATHLEN];
+    if (os::dll_locate_lib(dll_name, sizeof(dll_name), Arguments::get_dll_dir(), "svml")) {
+      libsvml = os::dll_load(dll_name, ebuf, sizeof ebuf);
     }
     if (libsvml != NULL) {
       // SVML method naming convention

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -39,6 +39,7 @@
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -7000,7 +7001,12 @@ address generate_avx_ghash_processBlocks() {
     // Get svml stub routine addresses
     void *libsvml = NULL;
     char ebuf[1024];
-    libsvml = os::dll_load(JNI_LIB_PREFIX "svml" JNI_LIB_SUFFIX, ebuf, sizeof ebuf);
+    char dll_name[JVM_MAXPATHLEN];
+    int ret = jio_snprintf(dll_name, sizeof(dll_name), "%s%slib%s" JNI_LIB_PREFIX "svml" JNI_LIB_SUFFIX,
+                       Arguments::get_java_home(), os::file_separator(), os::file_separator());
+    if (ret != -1) {
+      libsvml = os::dll_load(dll_name, ebuf, sizeof ebuf);
+    }
     if (libsvml != NULL) {
       // SVML method naming convention
       //   All the methods are named as __svml_op<T><N>_ha_<VV>

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7001,11 +7001,13 @@ address generate_avx_ghash_processBlocks() {
     // Get svml stub routine addresses
     void *libsvml = NULL;
     char ebuf[1024];
-    char dll_name[JVM_MAXPATHLEN];
-    int ret = jio_snprintf(dll_name, sizeof(dll_name), "%s%slib%s" JNI_LIB_PREFIX "svml" JNI_LIB_SUFFIX,
-                       Arguments::get_java_home(), os::file_separator(), os::file_separator());
+    char dll_path[JVM_MAXPATHLEN];
+    int ret = jio_snprintf(dll_path, sizeof(dll_path), "%s%slib", Arguments::get_java_home(), os::file_separator());
     if (ret != -1) {
-      libsvml = os::dll_load(dll_name, ebuf, sizeof ebuf);
+      char dll_name[JVM_MAXPATHLEN];
+      if (os::dll_locate_lib(dll_name, sizeof(dll_name), dll_path, "svml")) {
+        libsvml = os::dll_load(dll_name, ebuf, sizeof ebuf);
+      }
     }
     if (libsvml != NULL) {
       // SVML method naming convention

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7002,7 +7002,11 @@ address generate_avx_ghash_processBlocks() {
     void *libsvml = NULL;
     char ebuf[1024];
     char dll_path[JVM_MAXPATHLEN];
+#ifdef _WINDOWS
+    int ret = jio_snprintf(dll_path, sizeof(dll_path), "%s%sbin", Arguments::get_java_home(), os::file_separator());
+#else
     int ret = jio_snprintf(dll_path, sizeof(dll_path), "%s%slib", Arguments::get_java_home(), os::file_separator());
+#endif
     if (ret != -1) {
       char dll_name[JVM_MAXPATHLEN];
       if (os::dll_locate_lib(dll_name, sizeof(dll_name), dll_path, "svml")) {

--- a/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269335
+ * @summary Tests SVML shared library is loaded successfully.
+ * @modules jdk.incubator.vector
+ * @requires vm.compiler2.enabled
+ * @requires os.arch == "x86_64" | os.arch == "amd64"
+ * @requires os.family == "linux" | os.family == "windows"
+ * @library /test/lib
+ * @run main LoadSvmlTest
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.Vector;
+import jdk.incubator.vector.VectorSpecies;
+
+
+public class LoadSvmlTest {
+
+    private static class VectorTest {
+
+        static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_PREFERRED;
+
+        public static void main(String[] args) throws Exception {
+            float a[] = new float [1024];
+            float r[] = new float [1024];
+
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                FloatVector av = FloatVector.fromArray(SPECIES, a, i);
+                av.lanewise(VectorOperators.SINH).intoArray(r, i);
+            }
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Xmn8m", "-Xlog:library=info",
+            "--add-modules=jdk.incubator.vector", 
+            "LoadSvmlTest$VectorTest");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        if (Platform.isWindows())
+          output.shouldContain("Loaded library svml.dll");
+        else
+          output.shouldContain("Loaded library libsvml.so");
+    }
+}

--- a/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
@@ -63,7 +63,7 @@ public class LoadSvmlTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xmn8m", "-Xlog:library=info",
             "--add-modules=jdk.incubator.vector",
-            "LoadSvmlTest$VectorTest");
+            VectorTest.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);

--- a/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
@@ -63,7 +63,7 @@ public class LoadSvmlTest {
     public static void main(String... args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xmn8m", "-Xlog:library=info",
-            "--add-modules=jdk.incubator.vector", 
+            "--add-modules=jdk.incubator.vector",
             "LoadSvmlTest$VectorTest");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
@@ -33,7 +33,6 @@
  * @run main LoadSvmlTest
  */
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -68,9 +67,6 @@ public class LoadSvmlTest {
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
-        if (Platform.isWindows())
-          output.shouldMatch("Loaded library .*svml.dll");
-        else
-          output.shouldMatch("Loaded library .*libsvml.so");
+        output.shouldMatch("Loaded library .*svml");
     }
 }

--- a/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadSvmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,8 +69,8 @@ public class LoadSvmlTest {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         if (Platform.isWindows())
-          output.shouldContain("Loaded library svml.dll");
+          output.shouldMatch("Loaded library .*svml.dll");
         else
-          output.shouldContain("Loaded library libsvml.so");
+          output.shouldMatch("Loaded library .*libsvml.so");
     }
 }


### PR DESCRIPTION
The OpenJDK 17 early access build from jdk.java.net fails to load svml library. 
We need to give full svml library path to dll_load call for the load to succeed.,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269335](https://bugs.openjdk.java.net/browse/JDK-8269335): Unable to load svml library


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/143.diff">https://git.openjdk.java.net/jdk17/pull/143.diff</a>

</details>
