### PR TITLE
8269260: Add AVX512 and other SSE + AVX combinations testing for tests which generate vector instructions

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -71,6 +71,29 @@ hotspot_native_sanity = \
 hotspot_containers = \
   containers
 
+hotspot_vector_1 = \
+  compiler/c2/cr6340864 \
+  compiler/codegen \
+  compiler/loopopts/superword \
+  compiler/vectorapi \
+  compiler/vectorization \
+  -compiler/codegen/aes \
+  -compiler/codegen/Test6875866.java \
+  -compiler/codegen/Test6935535.java \
+  -compiler/codegen/TestGCMStorePlacement.java \
+  -compiler/codegen/TestTrichotomyExpressions.java \
+  -compiler/loopopts/superword/Vec_MulAddS2I.java \
+  -compiler/vectorapi/VectorRebracket128Test.java
+
+hotspot_vector_2 = \
+  compiler/intrinsics \
+  compiler/codegen/aes \
+  compiler/codegen/Test6875866.java \
+  compiler/codegen/Test6935535.java \
+  compiler/loopopts/superword/Vec_MulAddS2I.java \
+  compiler/vectorapi/VectorRebracket128Test.java \
+  -compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
+
 tier1_common = \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \


### PR DESCRIPTION
[8269179](https://bugs.openjdk.java.net/browse/JDK-8269179) bug shows that we (Oracle) don't test enough different vectors instructions on x64.

I suggest to create new HotSpot compiler test groups for such tests and together with jdk_vector (jdk/incubator/vector) group run them with different SSE and AVX HotSpot flags combinations: 
```
-XX:UseAVX=3 
-XX:UseAVX=2 
-XX:UseAVX=1 
-XX:UseAVX=0 
-XX:UseAVX=0 -XX:UseSSE=3 
-XX:UseAVX=0 -XX:UseSSE=2 (this is minimal setting for 64 bit)
```

Here my suggesting how to run them on windows-x64-debug and linux-x64-debug: 
```
hs-tier2: 
  hotspot_vector_1 - run with all flags combinations listed in Description 
  hotspot_vector_2 - run with `-XX:UseAVX=3` only 

hs-tier3: 
  jdk_vector - run with all flags combinations listed in Description 
  hotspot_vector_2 - run with all combinations except `-XX:UseAVX=3`
```

Tier1 already runs these tests in default mode.

Tested hs-tier1-3 internally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269260](https://bugs.openjdk.java.net/browse/JDK-8269260): Add AVX512 and other SSE + AVX combinations testing for tests which generate vector instructions


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/144.diff">https://git.openjdk.java.net/jdk17/pull/144.diff</a>

</details>
