### PR TITLE
8269354: javac crashes when processing parenthesized pattern in instanceof

### DIFF
--- a/test/langtools/tools/javac/patterns/Parenthesized.java
+++ b/test/langtools/tools/javac/patterns/Parenthesized.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8269354
  * @summary Test parenthesized pattern
  * @compile --enable-preview -source ${jdk.version} Parenthesized.java
  * @run main/othervm --enable-preview Parenthesized
@@ -46,6 +46,8 @@ public class Parenthesized {
         if (o instanceof (String s && s.isEmpty())) {
             System.err.println("OK: " + s);
         }
+        boolean b1 = o instanceof (String s && s.isEmpty());
+        boolean b2 = o instanceof String s && s.isEmpty();
     }
 
 }


### PR DESCRIPTION
When having code like:
```
if (o instanceof String s) {
     System.err.println(s);
}
```

`javac` needs to hoist the `s` binding variable out of the `if` statement. This is done through `BindingContext` in `TransPatterns`. Sometimes, there is no statement out of which the variable would need to be hoisted, like:
```
boolean b = o instanceof String s && !s.isEmpty();
```

so some expressions (`&&` in the example) also serve as a place where the binding variables can be hoisted. With the addition of parenthesized and guarded patterns, the `instanceof` expression needs to be one of such expressions so that in expressions like:
```
boolean b = o instanceof (String s && !s.isEmpty());
```

the `s.isEmpty()` uses the correct translated/hoisted variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269354](https://bugs.openjdk.java.net/browse/JDK-8269354): javac crashes when processing parenthesized pattern in instanceof


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/147.diff">https://git.openjdk.java.net/jdk17/pull/147.diff</a>

</details>
