### PR TITLE
JDK-8269351: Proxy::newProxyInstance and MethodHandleProxies::asInterfaceInstance should reject sealed interfaces

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -59,7 +59,8 @@ public class MethodHandleProxies {
      * even though it re-declares the {@code Object.equals} method and also
      * declares default methods, such as {@code Comparator.reverse}.
      * <p>
-     * The interface must be public.  No additional access checks are performed.
+     * The interface must be public and not {@linkplain Class#isSealed() sealed}.
+     * No additional access checks are performed.
      * <p>
      * The resulting instance of the required type will respond to
      * invocation of the type's uniquely named method by calling
@@ -156,6 +157,8 @@ public class MethodHandleProxies {
     public static <T> T asInterfaceInstance(final Class<T> intfc, final MethodHandle target) {
         if (!intfc.isInterface() || !Modifier.isPublic(intfc.getModifiers()))
             throw newIllegalArgumentException("not a public interface", intfc.getName());
+        if (intfc.isSealed())
+            throw newIllegalArgumentException("a sealed interface", intfc.getName());
         final MethodHandle mh;
         if (System.getSecurityManager() != null) {
             final Class<?> caller = Reflection.getCallerClass();

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -710,6 +710,10 @@ public class Proxy implements java.io.Serializable {
                     throw new IllegalArgumentException(intf.getName() + " is a hidden interface");
                 }
 
+                if (intf.isSealed()) {
+                    throw new IllegalArgumentException(intf.getName() + " is a sealed interface");
+                }
+
                 /*
                  * Verify that the class loader resolves the name of this
                  * interface to the same Class object.
@@ -930,7 +934,8 @@ public class Proxy implements java.io.Serializable {
      * if any of the following restrictions is violated:</a>
      * <ul>
      * <li>All of {@code Class} objects in the given {@code interfaces} array
-     * must represent {@linkplain Class#isHidden() non-hidden} interfaces,
+     * must represent {@linkplain Class#isHidden() non-hidden} and
+     * {@linkplain Class#isSealed() non-sealed} interfaces,
      * not classes or primitive types.
      *
      * <li>No two elements in the {@code interfaces} array may

--- a/test/jdk/java/lang/invoke/MethodHandlesProxiesTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesProxiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8206955
+ * @bug 8206955 8269351
  * @run testng/othervm -ea -esa test.java.lang.invoke.MethodHandlesProxiesTest
  */
 
@@ -98,5 +98,25 @@ public class MethodHandlesProxiesTest {
         assertEquals(proxy.a(), "OA");
         assertEquals(proxy.b(), "OB");
         assertEquals(proxy.c(), "OC");
+    }
+
+    public sealed interface Intf permits NonSealedInterface {
+        String m();
+    }
+
+    public non-sealed interface NonSealedInterface extends Intf {
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testSealedInterface() {
+        MethodHandle target = MethodHandles.constant(String.class, "Sealed");
+        MethodHandleProxies.asInterfaceInstance(Intf.class, target);
+    }
+
+    @Test
+    public void testNonSealedInterface() {
+        MethodHandle target = MethodHandles.constant(String.class, "Non-Sealed");
+        NonSealedInterface proxy = MethodHandleProxies.asInterfaceInstance(NonSealedInterface.class, target);
+        assertEquals(proxy.m(), "Non-Sealed");
     }
 }

--- a/test/jdk/java/lang/reflect/Proxy/SealedInterfaceTest.java
+++ b/test/jdk/java/lang/reflect/Proxy/SealedInterfaceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269351
+ * @run testng SealedInterfaceTest
+ */
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class SealedInterfaceTest {
+    sealed interface Intf permits NonSealedInterface {
+        void m1();
+    }
+
+    non-sealed interface NonSealedInterface extends Intf {
+        void m2();
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testSealedInterface() {
+        Proxy.newProxyInstance(SealedInterfaceTest.class.getClassLoader(),
+                new Class<?>[]{ Intf.class },
+                new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                        return null;
+                    }
+                });
+    }
+
+    @Test
+    public void testNonSealedInterface() {
+        Proxy.newProxyInstance(SealedInterfaceTest.class.getClassLoader(),
+                new Class<?>[]{ NonSealedInterface.class },
+                new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                        return null;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
`java.lang.reflect.Proxy::newProxyInstance` and `java.lang.invoke.MethodHandleProxies::asInterfaceInstance` do not specify how to deal with sealed interfaces.  These APIs should reject  sealed interface with `IllegalArgumentException` which is thrown if the given interface is invalid.

Please review CSR:
    https://bugs.openjdk.java.net/browse/JDK-8269396

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269351](https://bugs.openjdk.java.net/browse/JDK-8269351): Proxy::newProxyInstance and MethodHandleProxies::asInterfaceInstance should reject sealed interfaces


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/148.diff">https://git.openjdk.java.net/jdk17/pull/148.diff</a>

</details>
