### PR TITLE
8269403: Fix jpackage tests to gracefully handle jpackage app launcher crashes

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -249,7 +249,9 @@ public final class Executor extends CommandArguments<Executor> {
 
             try {
                 Thread.sleep(wait * 1000);
-            } catch (Exception ex) {} // Ignore
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+            }            
 
             count++;
         } while (count < max);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ public final class Executor extends CommandArguments<Executor> {
                 Thread.sleep(wait * 1000);
             } catch (InterruptedException ex) {
                 throw new RuntimeException(ex);
-            }            
+            }
 
             count++;
         } while (count < max);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -399,8 +399,11 @@ public final class HelloApp {
 
         public void executeAndVerifyOutput(boolean removePath,
                 List<String> launcherArgs, List<String> appArgs) {
-            getExecutor(launcherArgs.toArray(new String[0])).dumpOutput()
-                    .setRemovePath(removePath).execute();
+            final int attempts = 3;
+            final int waitBetweenAttemptsSeconds = 5;
+            getExecutor(launcherArgs.toArray(new String[0])).dumpOutput().setRemovePath(
+                    removePath).executeAndRepeatUntilExitCode(0, attempts,
+                            waitBetweenAttemptsSeconds);
             Path outputFile = TKit.workDir().resolve(OUTPUT_FILENAME);
             verifyOutputFile(outputFile, appArgs, params);
         }


### PR DESCRIPTION
jpackage app launcher randomly crashes JVM at termination in EMS enabled JDK builds.
Until the root cause of the issue is understood and fixed let's add a workaround to jpackage tests to run test app few more times if the first attempt resulted in app crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269403](https://bugs.openjdk.java.net/browse/JDK-8269403): Fix jpackage tests to gracefully handle jpackage app launcher crashes


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/153.diff">https://git.openjdk.java.net/jdk17/pull/153.diff</a>

</details>
