### PR TITLE
8258746: illegal access to global field _jvmci_old_thread_counters by terminated thread causes crash

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1239,11 +1239,6 @@ JavaThread::~JavaThread() {
 
 #if INCLUDE_JVMCI
   if (JVMCICounterSize > 0) {
-    if (jvmci_counters_include(this)) {
-      for (int i = 0; i < JVMCICounterSize; i++) {
-        _jvmci_old_thread_counters[i] += _jvmci_counters[i];
-      }
-    }
     FREE_C_HEAP_ARRAY(jlong, _jvmci_counters);
   }
 #endif // INCLUDE_JVMCI
@@ -1499,6 +1494,17 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
     _timer_exit_phase3.stop();
     _timer_exit_phase4.start();
   }
+
+#if INCLUDE_JVMCI
+  if (JVMCICounterSize > 0) {
+    if (jvmci_counters_include(this)) {
+      for (int i = 0; i < JVMCICounterSize; i++) {
+        _jvmci_old_thread_counters[i] += _jvmci_counters[i];
+      }
+    }
+  }
+#endif // INCLUDE_JVMCI
+
   // Remove from list of active threads list, and notify VM thread if we are the last non-daemon thread
   Threads::remove(this, daemon);
 


### PR DESCRIPTION
This change moves the access to the global field _jvmci_old_thread_counters from the thread destructor to JavaThread::exit().  See the JBS issue for more details.  The free of _jvmci_counters is left in the destructor intentionally, as it is allocated in the JavaThread constructor and not all termination paths go through JavaThread::exit().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258746](https://bugs.openjdk.java.net/browse/JDK-8258746): illegal access to global field _jvmci_old_thread_counters by terminated thread causes crash


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/154/head:pull/154` \
`$ git checkout pull/154`

Update a local copy of the PR: \
`$ git checkout pull/154` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 154`

View PR using the GUI difftool: \
`$ git pr show -t 154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/154.diff">https://git.openjdk.java.net/jdk17/pull/154.diff</a>

</details>
