### PR TITLE
8269304: Regression ~5% in 2005 in b27

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4514,7 +4514,9 @@ bool Compile::coarsened_locks_consistent() {
     bool modified = false; // track locks kind modifications
     Lock_List* locks_list = (Lock_List*)_coarsened_locks.at(i);
     uint size = locks_list->size();
-    if (size != locks_list->origin_cnt()) {
+    if (size == 0) {
+      unbalanced = false; // All locks were eliminated - good
+    } else if (size != locks_list->origin_cnt()) {
       unbalanced = true; // Some locks were removed from list
     } else {
       for (uint j = 0; j < size; j++) {


### PR DESCRIPTION
JDK-8268347 changes missed check for valid case when all locks/unlocks in coarsened group were eliminated.
As result methods were recompiled without locks coarsening optimization leaving locks in code.

Tested tier1-3, xcomp, performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269304](https://bugs.openjdk.java.net/browse/JDK-8269304): Regression ~5% in 2005 in b27


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/155.diff">https://git.openjdk.java.net/jdk17/pull/155.diff</a>

</details>
