### PR TITLE
8269486: CallerAccessTest fails for non server variant

### DIFF
--- a/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
+++ b/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
@@ -50,14 +50,14 @@ public class CallerAccessTest {
         Map<String, String> env = pb.environment();
 
         String libDir = Platform.libDir().toString();
-        String serverDir = Platform.jvmLibDir().toString();
+        String vmDir = Platform.jvmLibDir().toString();
 
         // set up shared library path
         String sharedLibraryPathEnvName = Platform.sharedLibraryPathVariableName();
         env.compute(sharedLibraryPathEnvName,
                     (k, v) -> (v == null) ? libDir : v + File.pathSeparator + libDir);
         env.compute(sharedLibraryPathEnvName,
-                    (k, v) -> (v == null) ? serverDir : v + File.pathSeparator + serverDir);
+                    (k, v) -> (v == null) ? vmDir : v + File.pathSeparator + vmDir);
 
         System.out.println("Launching: " + launcher + " shared library path: " +
                            env.get(sharedLibraryPathEnvName));

--- a/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
+++ b/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@
 import java.io.File;
 import java.util.Map;
 import jdk.test.lib.Platform;
-import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 import java.io.IOException;
@@ -50,10 +49,8 @@ public class CallerAccessTest {
         ProcessBuilder pb = new ProcessBuilder(launcher.toString());
         Map<String, String> env = pb.environment();
 
-        String libName = Platform.isWindows() ? "bin" : "lib";
-        Path libPath = Paths.get(Utils.TEST_JDK).resolve(libName);
-        String libDir = libPath.toAbsolutePath().toString();
-        String serverDir = libPath.resolve("server").toAbsolutePath().toString();
+        String libDir = Platform.libDir().toString();
+        String serverDir = Platform.jvmLibDir().toString();
 
         // set up shared library path
         String sharedLibraryPathEnvName = Platform.sharedLibraryPathVariableName();


### PR DESCRIPTION
Hi,

please review this small fix. The test case uses a custom launcher and before launching the JVM, it adds the "lib" and "lib/server" directories to the environment variable which controls the native library search path. For non server variants, the second directory is not called "lib/server", but "lib/client", for instance.

I changed the test case to use the utility methods in `Platform` to get the correct paths, dependent on the VM variant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269486](https://bugs.openjdk.java.net/browse/JDK-8269486): CallerAccessTest fails for non server variant


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 84b2354279b0cb5a32e6768e9c816fdd9ce063a7
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 84b2354279b0cb5a32e6768e9c816fdd9ce063a7
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/159.diff">https://git.openjdk.java.net/jdk17/pull/159.diff</a>

</details>
