### PR TITLE
8269529: javax/swing/reliability/HangDuringStaticInitialization.java fails in Windows debug build

### DIFF
--- a/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
+++ b/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
+++ b/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
@@ -33,6 +33,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 /**
  * @test
  * @bug 8189604 8208702
+ * @requires !vm.debug | os.family != "windows"
  * @run main/othervm -Djava.awt.headless=false HangDuringStaticInitialization
  * @run main/othervm -Djava.awt.headless=true HangDuringStaticInitialization
  */


### PR DESCRIPTION
Exclude test on Windows if VM is from a debug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269529](https://bugs.openjdk.java.net/browse/JDK-8269529): javax/swing/reliability/HangDuringStaticInitialization.java fails in Windows debug build


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 9f5074034030feec19da9ee32892e7b02e863c99
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/160.diff">https://git.openjdk.java.net/jdk17/pull/160.diff</a>

</details>
