### PR TITLE
8268350: Remove assert that ensures thread identifier remains the same

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -87,7 +87,7 @@ void ParallelArguments::initialize() {
   }
 
   if (FLAG_IS_DEFAULT(ParallelRefProcEnabled) && ParallelGCThreads > 1) {
-    //FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
+    FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
   }
 }
 

--- a/src/hotspot/share/gc/shared/copyFailedInfo.hpp
+++ b/src/hotspot/share/gc/shared/copyFailedInfo.hpp
@@ -71,12 +71,7 @@ class PromotionFailedInfo : public CopyFailedInfo {
 
   void register_copy_failure(size_t size) {
     CopyFailedInfo::register_copy_failure(size);
-    if (_thread_trace_id == 0) {
-      _thread_trace_id = JFR_THREAD_ID(Thread::current());
-    } else {
-      assert(JFR_THREAD_ID(Thread::current()) == _thread_trace_id,
-        "The PromotionFailedInfo should be thread local.");
-    }
+    _thread_trace_id = JFR_THREAD_ID(Thread::current());
   }
 
   void reset() {

--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -51,7 +51,7 @@ public class TestParallelRefProc {
         }
         if (GC.Parallel.isSupported()) {
             noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseParallelGC" }, false);
+            testFlag(new String[] { "-XX:+UseParallelGC" }, true);
         }
         if (GC.G1.isSupported()) {
             noneGCSupported = false;


### PR DESCRIPTION
This fix is divided into two commits: The first commit reverts the temporary 8268537 fixup to the problem that is properly resolved in this PR, the second commit removes the assert that ensures thread identifier remains the same for JFR events. It also always reassign a new thread identifier as it can not be known that it will remain the same after first assignment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268350](https://bugs.openjdk.java.net/browse/JDK-8268350): Remove assert that ensures thread identifier remains the same


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/161.diff">https://git.openjdk.java.net/jdk17/pull/161.diff</a>

</details>
