### PR TITLE
8269513: Clarify the spec wrt `useOldISOCodes` system property

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -457,7 +457,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@systemProperty java.locale.useOldISOCodes} reverts the behavior
  * back to prior to Java SE 17 one. If the system property is set
  * to {@code true}, those three current language codes are mapped to their
- * backward compatible forms.
+ * backward compatible forms. It is only read at the Java runtime startup,
+ * so the later call to {@code System.setProperty()} won't affect the backward
+ * compatible behavior.
  *
  * <p>The APIs added in 1.7 map between the old and new language codes,
  * maintaining the mapped codes internal to Locale (so that

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -458,7 +458,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * back to that of before Java SE 17. If the system property is set to
  * {@code true}, those three current language codes are mapped to their
  * backward compatible forms. The property is only read at Java runtime
- * startup, so subsequent calls to {@code System.setProperty()} will
+ * startup and subsequent calls to {@code System.setProperty()} will
  * have no effect.
  *
  * <p>The APIs added in 1.7 map between the old and new language codes,

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -455,10 +455,10 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  * <p>For the backward compatible behavior, the system property
  * {@systemProperty java.locale.useOldISOCodes} reverts the behavior
- * back to prior to Java SE 17 one. If the system property is set
- * to {@code true}, those three current language codes are mapped to their
- * backward compatible forms. It is only read at the Java runtime startup,
- * so the later call to {@code System.setProperty()} won't affect the backward
+ * back to that of before Java SE 17. If the system property is set to
+ * {@code true}, those three current language codes are mapped to their
+ * backward compatible forms. It is only read at Java runtime startup, so a
+ * subsequent call to {@code System.setProperty()} won't affect backward
  * compatible behavior.
  *
  * <p>The APIs added in 1.7 map between the old and new language codes,

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -457,9 +457,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@systemProperty java.locale.useOldISOCodes} reverts the behavior
  * back to that of before Java SE 17. If the system property is set to
  * {@code true}, those three current language codes are mapped to their
- * backward compatible forms. It is only read at Java runtime startup, so a
- * subsequent call to {@code System.setProperty()} won't affect backward
- * compatible behavior.
+ * backward compatible forms. The property is only read at Java runtime
+ * startup, so subsequent calls to {@code System.setProperty()} will
+ * have no effect.
  *
  * <p>The APIs added in 1.7 map between the old and new language codes,
  * maintaining the mapped codes internal to Locale (so that


### PR DESCRIPTION
Please review this small doc change to the system property. Accompanying CSR has also been created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269513](https://bugs.openjdk.java.net/browse/JDK-8269513): Clarify the spec wrt `useOldISOCodes` system property


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 3d25418cd765c3d6352d32a09360e803045d38d4
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/163.diff">https://git.openjdk.java.net/jdk17/pull/163.diff</a>

</details>
