### PR TITLE
8269543: The warning for System::setSecurityManager should only appear once for each caller

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -331,7 +331,7 @@ public final class System {
     private static class CallersHolder {
         // Remember callers of setSecurityManager() here so that warning
         // is only printed once for each different caller
-        final static Map<String, Boolean> callers
+        final static Map<Class<?>, Boolean> callers
             = Collections.synchronizedMap(new WeakHashMap<>());
     }
 
@@ -387,14 +387,14 @@ public final class System {
     public static void setSecurityManager(@SuppressWarnings("removal") SecurityManager sm) {
         if (allowSecurityManager()) {
             var callerClass = Reflection.getCallerClass();
-            URL url = codeSource(callerClass);
-            final String source;
-            if (url == null) {
-                source = callerClass.getName();
-            } else {
-                source = callerClass.getName() + " (" + url + ")";
-            }
-            if (CallersHolder.callers.putIfAbsent(source, true) == null) {
+            if (CallersHolder.callers.putIfAbsent(callerClass, true) == null) {
+                URL url = codeSource(callerClass);
+                final String source;
+                if (url == null) {
+                    source = callerClass.getName();
+                } else {
+                    source = callerClass.getName() + " (" + url + ")";
+                }
                 initialErrStream.printf("""
                         WARNING: A terminally deprecated method in java.lang.System has been called
                         WARNING: System::setSecurityManager has been called by %s

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -328,10 +328,10 @@ public final class System {
     private static native void setOut0(PrintStream out);
     private static native void setErr0(PrintStream err);
 
-    private static class CallerHolder {
+    private static class CallersHolder {
         // Remember callers of setSecurityManager() here so that warning
         // is only printed once for each different caller
-        final static Map<String, Boolean> callersOfSSM
+        final static Map<String, Boolean> callers
             = Collections.synchronizedMap(new WeakHashMap<>());
     }
 
@@ -394,7 +394,7 @@ public final class System {
             } else {
                 source = callerClass.getName() + " (" + url + ")";
             }
-            if (CallerHolder.callersOfSSM.putIfAbsent(source, true) == null) {
+            if (CallersHolder.callers.putIfAbsent(source, true) == null) {
                 initialErrStream.printf("""
                         WARNING: A terminally deprecated method in java.lang.System has been called
                         WARNING: System::setSecurityManager has been called by %s

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266459 8268349
+ * @bug 8266459 8268349 8269543
  * @summary check various warnings
  * @library /test/lib
  */
@@ -72,6 +72,9 @@ public class SecurityManagerWarnings {
             // to the original System.err and will not be swallowed.
             System.setErr(new PrintStream(new ByteArrayOutputStream()));
             try {
+                // Set twice and ensure the warning only appears once.
+                // First set to null so that the 2nd call always succeeds.
+                System.setSecurityManager(null);
                 System.setSecurityManager(new SecurityManager());
             } catch (Exception e) {
                 // Exception messages must show in original stderr
@@ -115,7 +118,8 @@ public class SecurityManagerWarnings {
                 .stderrShouldContain("WARNING: A terminally deprecated method in java.lang.System has been called")
                 .stderrShouldContain("WARNING: System::setSecurityManager has been called by SecurityManagerWarnings (" + uri + ")")
                 .stderrShouldContain("WARNING: Please consider reporting this to the maintainers of SecurityManagerWarnings")
-                .stderrShouldContain("WARNING: System::setSecurityManager will be removed in a future release");
+                .stderrShouldContain("WARNING: System::setSecurityManager will be removed in a future release")
+                .stderrShouldNotMatch("(?s)terminally.*terminally");    // appears only once
     }
 
     static OutputAnalyzer run(String prop, String cp) throws Exception {
@@ -133,6 +137,7 @@ public class SecurityManagerWarnings {
                     "-Djava.security.policy=policy",
                     "SecurityManagerWarnings", "run");
         }
-        return ProcessTools.executeProcess(pb);
+        return ProcessTools.executeProcess(pb)
+                .stderrShouldNotContain("AccessControlException");
     }
 }


### PR DESCRIPTION
Add a cache to record which sources have called `System::setSecurityManager` and only print out warning lines once for each.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269543](https://bugs.openjdk.java.net/browse/JDK-8269543): The warning for System::setSecurityManager should only appear once for each caller


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/166.diff">https://git.openjdk.java.net/jdk17/pull/166.diff</a>

</details>
