### PR TITLE
JDK-8249646: Runtime.exec(String, String[], File) documentation contains literal {@link ...}

### DIFF
--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -200,7 +200,7 @@ public class Runtime {
      *
      * @throws  SecurityException
      *          If a security manager is present and it denies
-     *          {@link RuntimePermission}("shutdownHooks")
+     *          {@link RuntimePermission}{@code ("shutdownHooks")}
      *
      * @see #removeShutdownHook
      * @see #halt(int)
@@ -230,7 +230,7 @@ public class Runtime {
      *
      * @throws  SecurityException
      *          If a security manager is present and it denies
-     *          {@link RuntimePermission}("shutdownHooks")
+     *          {@link RuntimePermission}{@code ("shutdownHooks")}
      *
      * @see #addShutdownHook
      * @see #exit(int)
@@ -369,7 +369,7 @@ public class Runtime {
      *
      * <p>More precisely, the {@code command} string is broken
      * into tokens using a {@link StringTokenizer} created by the call
-     * {@code new {@link StringTokenizer}(command)} with no
+     * {@code new StringTokenizer(command)} with no
      * further modification of the character categories.  The tokens
      * produced by the tokenizer are then placed in the new string
      * array {@code cmdarray}, in the same order.


### PR DESCRIPTION
Please review a trivial `noreg-doc` fix for some javadoc tags for `java.lang.Runtime` for JDK17

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249646](https://bugs.openjdk.java.net/browse/JDK-8249646): Runtime.exec(String, String[], File) documentation contains literal {@link ...}


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/167.diff">https://git.openjdk.java.net/jdk17/pull/167.diff</a>

</details>
