### PR TITLE
8269568: JVM crashes when running VectorMask query tests

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -3863,6 +3863,9 @@ void C2_MacroAssembler::vector_mask_operation(int opc, Register dst, XMMRegister
   vpsubb(xtmp, xtmp, mask, vec_enc);
   evpmovb2m(ktmp, xtmp, vec_enc);
   kmovql(tmp, ktmp);
+  if (masklen < 64) {
+    andq(tmp, (((jlong)1 << masklen) - 1));
+  }
   switch(opc) {
     case Op_VectorMaskTrueCount:
       popcntq(dst, tmp);
@@ -3887,6 +3890,9 @@ void C2_MacroAssembler::vector_mask_operation(int opc, Register dst, XMMRegister
   vpxor(xtmp, xtmp, xtmp, vec_enc);
   vpsubb(xtmp, xtmp, mask, vec_enc);
   vpmovmskb(tmp, xtmp, vec_enc);
+  if (masklen < 64) {
+    andq(tmp, (((jlong)1 << masklen) - 1));
+  }
   switch(opc) {
     case Op_VectorMaskTrueCount:
       popcntq(dst, tmp);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -3863,9 +3863,6 @@ void C2_MacroAssembler::vector_mask_operation(int opc, Register dst, XMMRegister
   vpsubb(xtmp, xtmp, mask, vec_enc);
   evpmovb2m(ktmp, xtmp, vec_enc);
   kmovql(tmp, ktmp);
-  if (masklen < 64) {
-    andq(tmp, (((jlong)1 << masklen) - 1));
-  }
   switch(opc) {
     case Op_VectorMaskTrueCount:
       popcntq(dst, tmp);

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -876,7 +876,7 @@ class VectorMaskOpNode : public TypeNode {
  public:
   VectorMaskOpNode(Node* mask, const Type* ty, int mopc):
     TypeNode(ty, 2), _mopc(mopc) {
-    assert(mask->Opcode() == Op_VectorStoreMask, "");
+    assert(mask->bottom_type()->is_vect()->element_basic_type() == T_BOOLEAN, "");
     init_req(1, mask);
   }
 

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -5234,14 +5234,16 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static void maskTrueCountByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5249,17 +5251,19 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static void maskLastTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5267,17 +5271,19 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -1132,11 +1132,6 @@ public class Byte128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5261,7 +5256,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5286,7 +5281,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5311,7 +5306,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -211,6 +211,21 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
@@ -1115,6 +1130,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5230,61 +5250,77 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -211,6 +211,21 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
@@ -1115,6 +1130,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5230,61 +5250,77 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -5234,14 +5234,16 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static void maskTrueCountByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5249,17 +5251,19 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static void maskLastTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5267,17 +5271,19 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -1132,11 +1132,6 @@ public class Byte256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5261,7 +5256,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5286,7 +5281,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5311,7 +5306,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -211,6 +211,21 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
@@ -1115,6 +1130,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5230,61 +5250,77 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -5234,14 +5234,16 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static void maskTrueCountByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5249,17 +5251,19 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static void maskLastTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5267,17 +5271,19 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -1132,11 +1132,6 @@ public class Byte512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5261,7 +5256,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5286,7 +5281,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5311,7 +5306,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -211,6 +211,21 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
@@ -1115,6 +1130,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5230,61 +5250,77 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Byte64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -5234,14 +5234,16 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static void maskTrueCountByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5249,17 +5251,19 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static void maskLastTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5267,17 +5271,19 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -1132,11 +1132,6 @@ public class Byte64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5261,7 +5256,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5286,7 +5281,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5311,7 +5306,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByte64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -1137,11 +1137,6 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5266,7 +5261,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5291,7 +5286,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5316,7 +5311,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -5239,14 +5239,16 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5254,17 +5256,19 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5272,17 +5276,19 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -216,6 +216,21 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
@@ -1120,6 +1135,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5235,61 +5255,77 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ByteMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ByteMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueByteMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ByteMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -211,6 +211,21 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
@@ -1251,6 +1266,11 @@ public class Double128VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4781,61 +4801,77 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -4785,14 +4785,16 @@ public class Double128VectorTests extends AbstractVectorTest {
     static void maskTrueCountDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4800,17 +4802,19 @@ public class Double128VectorTests extends AbstractVectorTest {
     static void maskLastTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4818,17 +4822,19 @@ public class Double128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -1268,11 +1268,6 @@ public class Double128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4812,7 +4807,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4837,7 +4832,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4862,7 +4857,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -4785,14 +4785,16 @@ public class Double256VectorTests extends AbstractVectorTest {
     static void maskTrueCountDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4800,17 +4802,19 @@ public class Double256VectorTests extends AbstractVectorTest {
     static void maskLastTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4818,17 +4822,19 @@ public class Double256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -211,6 +211,21 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
@@ -1251,6 +1266,11 @@ public class Double256VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4781,61 +4801,77 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -1268,11 +1268,6 @@ public class Double256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4812,7 +4807,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4837,7 +4832,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4862,7 +4857,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -4785,14 +4785,16 @@ public class Double512VectorTests extends AbstractVectorTest {
     static void maskTrueCountDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4800,17 +4802,19 @@ public class Double512VectorTests extends AbstractVectorTest {
     static void maskLastTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4818,17 +4822,19 @@ public class Double512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -211,6 +211,21 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
@@ -1251,6 +1266,11 @@ public class Double512VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4781,61 +4801,77 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -1268,11 +1268,6 @@ public class Double512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4812,7 +4807,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4837,7 +4832,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4862,7 +4857,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -4785,14 +4785,16 @@ public class Double64VectorTests extends AbstractVectorTest {
     static void maskTrueCountDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4800,17 +4802,19 @@ public class Double64VectorTests extends AbstractVectorTest {
     static void maskLastTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4818,17 +4822,19 @@ public class Double64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -1268,11 +1268,6 @@ public class Double64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4812,7 +4807,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4837,7 +4832,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4862,7 +4857,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -211,6 +211,21 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
@@ -1251,6 +1266,11 @@ public class Double64VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4781,61 +4801,77 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDouble64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Double64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -4790,14 +4790,16 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4805,17 +4807,19 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4823,17 +4827,19 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -216,6 +216,21 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
@@ -1256,6 +1271,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4786,61 +4806,77 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, DoubleMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, DoubleMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, DoubleMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -1273,11 +1273,6 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4817,7 +4812,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4842,7 +4837,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4867,7 +4862,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueDoubleMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -211,6 +211,21 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
@@ -1261,6 +1276,11 @@ public class Float128VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4759,61 +4779,77 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -4763,14 +4763,16 @@ public class Float128VectorTests extends AbstractVectorTest {
     static void maskTrueCountFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4778,17 +4780,19 @@ public class Float128VectorTests extends AbstractVectorTest {
     static void maskLastTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4796,17 +4800,19 @@ public class Float128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -1278,11 +1278,6 @@ public class Float128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4790,7 +4785,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4815,7 +4810,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4840,7 +4835,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -1278,11 +1278,6 @@ public class Float256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4790,7 +4785,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4815,7 +4810,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4840,7 +4835,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -211,6 +211,21 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
@@ -1261,6 +1276,11 @@ public class Float256VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4759,61 +4779,77 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -4763,14 +4763,16 @@ public class Float256VectorTests extends AbstractVectorTest {
     static void maskTrueCountFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4778,17 +4780,19 @@ public class Float256VectorTests extends AbstractVectorTest {
     static void maskLastTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4796,17 +4800,19 @@ public class Float256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueFloat256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -4763,14 +4763,16 @@ public class Float512VectorTests extends AbstractVectorTest {
     static void maskTrueCountFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4778,17 +4780,19 @@ public class Float512VectorTests extends AbstractVectorTest {
     static void maskLastTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4796,17 +4800,19 @@ public class Float512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -1278,11 +1278,6 @@ public class Float512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4790,7 +4785,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4815,7 +4810,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4840,7 +4835,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -211,6 +211,21 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
@@ -1261,6 +1276,11 @@ public class Float512VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4759,61 +4779,77 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -4763,14 +4763,16 @@ public class Float64VectorTests extends AbstractVectorTest {
     static void maskTrueCountFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4778,17 +4780,19 @@ public class Float64VectorTests extends AbstractVectorTest {
     static void maskLastTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4796,17 +4800,19 @@ public class Float64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -1278,11 +1278,6 @@ public class Float64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4790,7 +4785,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4815,7 +4810,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4840,7 +4835,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -211,6 +211,21 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
@@ -1261,6 +1276,11 @@ public class Float64VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4759,61 +4779,77 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloat64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Float64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -4768,14 +4768,16 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -4783,17 +4785,19 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -4801,17 +4805,19 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -216,6 +216,21 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
@@ -1266,6 +1281,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -4764,61 +4784,77 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, FloatMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, FloatMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, FloatMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -1283,11 +1283,6 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -4795,7 +4790,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4820,7 +4815,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -4845,7 +4840,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueFloatMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -5188,14 +5188,16 @@ public class Int128VectorTests extends AbstractVectorTest {
     static void maskTrueCountInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5203,17 +5205,19 @@ public class Int128VectorTests extends AbstractVectorTest {
     static void maskLastTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5221,17 +5225,19 @@ public class Int128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -1092,7 +1092,6 @@ public class Int128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5211,7 +5210,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5236,7 +5235,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5261,7 +5260,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -211,6 +211,21 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
@@ -1076,6 +1091,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
 
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
@@ -5184,61 +5200,77 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -1092,7 +1092,6 @@ public class Int256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5211,7 +5210,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5236,7 +5235,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5261,7 +5260,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -211,6 +211,21 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
@@ -1076,6 +1091,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
 
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
@@ -5184,61 +5200,77 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -5188,14 +5188,16 @@ public class Int256VectorTests extends AbstractVectorTest {
     static void maskTrueCountInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5203,17 +5205,19 @@ public class Int256VectorTests extends AbstractVectorTest {
     static void maskLastTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5221,17 +5225,19 @@ public class Int256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueInt256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -5188,14 +5188,16 @@ public class Int512VectorTests extends AbstractVectorTest {
     static void maskTrueCountInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5203,17 +5205,19 @@ public class Int512VectorTests extends AbstractVectorTest {
     static void maskLastTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5221,17 +5225,19 @@ public class Int512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -211,6 +211,21 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
@@ -1076,6 +1091,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
 
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
@@ -5184,61 +5200,77 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -1092,7 +1092,6 @@ public class Int512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5211,7 +5210,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5236,7 +5235,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5261,7 +5260,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -5188,14 +5188,16 @@ public class Int64VectorTests extends AbstractVectorTest {
     static void maskTrueCountInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5203,17 +5205,19 @@ public class Int64VectorTests extends AbstractVectorTest {
     static void maskLastTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5221,17 +5225,19 @@ public class Int64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -211,6 +211,21 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
@@ -1076,6 +1091,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
 
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
@@ -5184,61 +5200,77 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Int64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -1092,7 +1092,6 @@ public class Int64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5211,7 +5210,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5236,7 +5235,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5261,7 +5260,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueInt64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -5193,14 +5193,16 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5208,17 +5210,19 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5226,17 +5230,19 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -1097,7 +1097,6 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5216,7 +5215,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5241,7 +5240,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5266,7 +5265,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = fr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -216,6 +216,21 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
@@ -1081,6 +1096,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
 
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
@@ -5189,61 +5205,77 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, IntMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, IntMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueIntMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = fr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, IntMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -1118,11 +1118,6 @@ public class Long128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
 
     static void replaceZero(long[] a, long v) {
         for (int i = 0; i < a.length; i++) {
@@ -5099,7 +5094,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5124,7 +5119,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5149,7 +5144,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -5072,14 +5072,16 @@ public class Long128VectorTests extends AbstractVectorTest {
     static void maskTrueCountLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5087,17 +5089,19 @@ public class Long128VectorTests extends AbstractVectorTest {
     static void maskLastTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5105,17 +5109,19 @@ public class Long128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -168,6 +168,21 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
@@ -1101,6 +1116,11 @@ public class Long128VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
 
@@ -5068,61 +5088,77 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -5072,14 +5072,16 @@ public class Long256VectorTests extends AbstractVectorTest {
     static void maskTrueCountLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5087,17 +5089,19 @@ public class Long256VectorTests extends AbstractVectorTest {
     static void maskLastTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5105,17 +5109,19 @@ public class Long256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -1118,11 +1118,6 @@ public class Long256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
 
     static void replaceZero(long[] a, long v) {
         for (int i = 0; i < a.length; i++) {
@@ -5099,7 +5094,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5124,7 +5119,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5149,7 +5144,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -168,6 +168,21 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
@@ -1101,6 +1116,11 @@ public class Long256VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
 
@@ -5068,61 +5088,77 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -5072,14 +5072,16 @@ public class Long512VectorTests extends AbstractVectorTest {
     static void maskTrueCountLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5087,17 +5089,19 @@ public class Long512VectorTests extends AbstractVectorTest {
     static void maskLastTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5105,17 +5109,19 @@ public class Long512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -168,6 +168,21 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
@@ -1101,6 +1116,11 @@ public class Long512VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
 
@@ -5068,61 +5088,77 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -1118,11 +1118,6 @@ public class Long512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
 
     static void replaceZero(long[] a, long v) {
         for (int i = 0; i < a.length; i++) {
@@ -5099,7 +5094,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5124,7 +5119,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5149,7 +5144,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -5072,14 +5072,16 @@ public class Long64VectorTests extends AbstractVectorTest {
     static void maskTrueCountLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5087,17 +5089,19 @@ public class Long64VectorTests extends AbstractVectorTest {
     static void maskLastTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5105,17 +5109,19 @@ public class Long64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -168,6 +168,21 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
@@ -1101,6 +1116,11 @@ public class Long64VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
 
@@ -5068,61 +5088,77 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Long64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -1118,11 +1118,6 @@ public class Long64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
 
     static void replaceZero(long[] a, long v) {
         for (int i = 0; i < a.length; i++) {
@@ -5099,7 +5094,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5124,7 +5119,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5149,7 +5144,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLong64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -173,6 +173,21 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
@@ -1106,6 +1121,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
 
@@ -5073,61 +5093,77 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, LongMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, LongMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, LongMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -5077,14 +5077,16 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5092,17 +5094,19 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5110,17 +5114,19 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -1123,11 +1123,6 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
 
     static void replaceZero(long[] a, long v) {
         for (int i = 0; i < a.length; i++) {
@@ -5104,7 +5099,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5129,7 +5124,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5154,7 +5149,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueLongMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -1122,11 +1122,6 @@ public class Short128VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5240,7 +5235,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5265,7 +5260,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5290,7 +5285,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -211,6 +211,21 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
@@ -1105,6 +1120,11 @@ public class Short128VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5209,61 +5229,77 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short128VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short128VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short128VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -5213,14 +5213,16 @@ public class Short128VectorTests extends AbstractVectorTest {
     static void maskTrueCountShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5228,17 +5230,19 @@ public class Short128VectorTests extends AbstractVectorTest {
     static void maskLastTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5246,17 +5250,19 @@ public class Short128VectorTests extends AbstractVectorTest {
     static void maskFirstTrueShort128VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -211,6 +211,21 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
@@ -1105,6 +1120,11 @@ public class Short256VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5209,61 +5229,77 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short256VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short256VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short256VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -1122,11 +1122,6 @@ public class Short256VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5240,7 +5235,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5265,7 +5260,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5290,7 +5285,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -5213,14 +5213,16 @@ public class Short256VectorTests extends AbstractVectorTest {
     static void maskTrueCountShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5228,17 +5230,19 @@ public class Short256VectorTests extends AbstractVectorTest {
     static void maskLastTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5246,17 +5250,19 @@ public class Short256VectorTests extends AbstractVectorTest {
     static void maskFirstTrueShort256VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -1122,11 +1122,6 @@ public class Short512VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5240,7 +5235,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5265,7 +5260,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5290,7 +5285,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -5213,14 +5213,16 @@ public class Short512VectorTests extends AbstractVectorTest {
     static void maskTrueCountShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5228,17 +5230,19 @@ public class Short512VectorTests extends AbstractVectorTest {
     static void maskLastTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5246,17 +5250,19 @@ public class Short512VectorTests extends AbstractVectorTest {
     static void maskFirstTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -211,6 +211,21 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
@@ -1105,6 +1120,11 @@ public class Short512VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5209,61 +5229,77 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short512VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short512VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort512VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short512VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -5213,14 +5213,16 @@ public class Short64VectorTests extends AbstractVectorTest {
     static void maskTrueCountShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5228,17 +5230,19 @@ public class Short64VectorTests extends AbstractVectorTest {
     static void maskLastTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5246,17 +5250,19 @@ public class Short64VectorTests extends AbstractVectorTest {
     static void maskFirstTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -211,6 +211,21 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
@@ -1105,6 +1120,11 @@ public class Short64VectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5209,61 +5229,77 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short64VectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short64VectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, Short64VectorTests::maskFirstTrue);
     }
 
     @DataProvider

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -1122,11 +1122,6 @@ public class Short64VectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5240,7 +5235,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5265,7 +5260,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5290,7 +5285,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShort64VectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -5218,14 +5218,16 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static void maskTrueCountShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -5233,17 +5235,19 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static void maskLastTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -5251,17 +5255,19 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static void maskFirstTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -1127,11 +1127,6 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         return new boolean[length];
     };
 
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new long[length];
@@ -5245,7 +5240,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5270,7 +5265,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -5295,7 +5290,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-        int[] r = ifr.apply(SPECIES.length());
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -216,6 +216,21 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
@@ -1110,6 +1125,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static final IntFunction<boolean[]> fmr = (vl) -> {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
+    };
+
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
     };
 
     static final IntFunction<long[]> lfr = (vl) -> {
@@ -5214,61 +5234,77 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCountShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ShortMaxVectorTests::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ShortMaxVectorTests::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrueShortMaxVectorTestsSmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+        int[] r = ifr.apply(SPECIES.length());
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, ShortMaxVectorTests::maskFirstTrue);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -415,14 +415,16 @@
     static void maskTrueCount$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int tcount = vmask.trueCount();
-            int expectedTcount = 0;
-            for (int j = i; j < i + SPECIES.length(); j++) {
-                expectedTcount += a[j] ? 1 : 0;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int tcount = vmask.trueCount();
+                int expectedTcount = 0;
+                for (int j = i; j < i + SPECIES.length(); j++) {
+                    expectedTcount += a[j] ? 1 : 0;
+                }
+                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
             }
-            Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
         }
     }
 
@@ -430,17 +432,19 @@
     static void maskLastTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ltrue = vmask.lastTrue();
-            int j = i + SPECIES.length() - 1;
-            for (; j >= i; j--) {
-                if (a[j]) break;
-            }
-            int expectedLtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ltrue = vmask.lastTrue();
+                int j = i + SPECIES.length() - 1;
+                for (; j >= i; j--) {
+                    if (a[j]) break;
+                }
+                int expectedLtrue = j - i;
 
-            Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
+                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+            }
         }
     }
 
@@ -448,17 +452,19 @@
     static void maskFirstTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
 
-        for (int i = 0; i < a.length; i += SPECIES.length()) {
-            var vmask = SPECIES.loadMask(a, i);
-            int ftrue = vmask.firstTrue();
-            int j = i;
-            for (; j < i + SPECIES.length() ; j++) {
-                if (a[j]) break;
-            }
-            int expectedFtrue = j - i;
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            for (int i = 0; i < a.length; i += SPECIES.length()) {
+                var vmask = SPECIES.loadMask(a, i);
+                int ftrue = vmask.firstTrue();
+                int j = i;
+                for (; j < i + SPECIES.length() ; j++) {
+                    if (a[j]) break;
+                }
+                int expectedFtrue = j - i;
 
-            Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
+                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+            }
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -422,11 +422,7 @@
     @Test(dataProvider = "maskProvider")
     static void maskTrueCount$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-#if[Int]
-        int[] r = fr.apply(SPECIES.length());
-#else[Int]
-        int[] r = ifr.apply(SPECIES.length());
-#end[Int]
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -451,11 +447,7 @@
     @Test(dataProvider = "maskProvider")
     static void maskLastTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-#if[Int]
-        int[] r = fr.apply(SPECIES.length());
-#else[Int]
-        int[] r = ifr.apply(SPECIES.length());
-#end[Int]
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
@@ -480,11 +472,7 @@
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
-#if[Int]
-        int[] r = fr.apply(SPECIES.length());
-#else[Int]
-        int[] r = ifr.apply(SPECIES.length());
-#end[Int]
+        int[] r = new int[a.length];
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -411,61 +411,89 @@
         }
     }
 
+    static int maskTrueCount(boolean[] a, int idx) {
+        int trueCount = 0;
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            trueCount += a[i] ? 1 : 0;
+        }
+        return trueCount;
+    }
+
     @Test(dataProvider = "maskProvider")
     static void maskTrueCount$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+#if[Int]
+        int[] r = fr.apply(SPECIES.length());
+#else[Int]
+        int[] r = ifr.apply(SPECIES.length());
+#end[Int]
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int tcount = vmask.trueCount();
-                int expectedTcount = 0;
-                for (int j = i; j < i + SPECIES.length(); j++) {
-                    expectedTcount += a[j] ? 1 : 0;
-                }
-                Assert.assertTrue(tcount == expectedTcount, "at index " + i + ", trueCount should be = " + expectedTcount + ", but is = " + tcount);
+                r[i] = vmask.trueCount();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, $vectorteststype$::maskTrueCount);
+    }
+
+    static int maskLastTrue(boolean[] a, int idx) {
+        int i = idx + SPECIES.length() - 1;
+        for (; i >= idx; i--) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskLastTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+#if[Int]
+        int[] r = fr.apply(SPECIES.length());
+#else[Int]
+        int[] r = ifr.apply(SPECIES.length());
+#end[Int]
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ltrue = vmask.lastTrue();
-                int j = i + SPECIES.length() - 1;
-                for (; j >= i; j--) {
-                    if (a[j]) break;
-                }
-                int expectedLtrue = j - i;
-
-                Assert.assertTrue(ltrue == expectedLtrue, "at index " + i +
-                    ", lastTrue should be = " + expectedLtrue + ", but is = " + ltrue);
+                r[i] = vmask.lastTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, $vectorteststype$::maskLastTrue);
+    }
+
+    static int maskFirstTrue(boolean[] a, int idx) {
+        int i = idx;
+        for (; i < idx + SPECIES.length(); i++) {
+            if (a[i]) {
+                break;
+            }
+        }
+        return i - idx;
     }
 
     @Test(dataProvider = "maskProvider")
     static void maskFirstTrue$vectorteststype$SmokeTest(IntFunction<boolean[]> fa) {
         boolean[] a = fa.apply(SPECIES.length());
+#if[Int]
+        int[] r = fr.apply(SPECIES.length());
+#else[Int]
+        int[] r = ifr.apply(SPECIES.length());
+#end[Int]
 
         for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
             for (int i = 0; i < a.length; i += SPECIES.length()) {
                 var vmask = SPECIES.loadMask(a, i);
-                int ftrue = vmask.firstTrue();
-                int j = i;
-                for (; j < i + SPECIES.length() ; j++) {
-                    if (a[j]) break;
-                }
-                int expectedFtrue = j - i;
-
-                Assert.assertTrue(ftrue == expectedFtrue, "at index " + i +
-                    ", firstTrue should be = " + expectedFtrue + ", but is = " + ftrue);
+                r[i] = vmask.firstTrue();
             }
         }
+
+        assertMaskReductionArraysEquals(r, a, $vectorteststype$::maskFirstTrue);
     }
 
 #if[!MaxBit]

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -242,6 +242,21 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
+    interface FMaskReductionOp {
+        int apply(boolean[] a, int idx);
+    }
+
+    static void assertMaskReductionArraysEquals(int[] r, boolean[] a, FMaskReductionOp f) {
+        int i = 0;
+        try {
+            for (; i < a.length; i += SPECIES.length()) {
+                Assert.assertEquals(r[i], f.apply(a, i));
+            }
+        } catch (AssertionError e) {
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
+        }
+    }
+
     static void assertInsertArraysEquals($type$[] r, $type$[] a, $type$ element, int index) {
         int i = 0;
         try {
@@ -1344,6 +1359,13 @@ public class $vectorteststype$ extends AbstractVectorTest {
         int length = BUFFER_REPS * vl;
         return new boolean[length];
     };
+
+#if[!Int]
+    static final IntFunction<int[]> ifr = (vl) -> {
+        int length = BUFFER_REPS * vl;
+        return new int[length];
+    };
+#end[!Int]
 
 #if[!Long]
     static final IntFunction<long[]> lfr = (vl) -> {

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -1360,13 +1360,6 @@ public class $vectorteststype$ extends AbstractVectorTest {
         return new boolean[length];
     };
 
-#if[!Int]
-    static final IntFunction<int[]> ifr = (vl) -> {
-        int length = BUFFER_REPS * vl;
-        return new int[length];
-    };
-#end[!Int]
-
 #if[!Long]
     static final IntFunction<long[]> lfr = (vl) -> {
         int length = BUFFER_REPS * vl;


### PR DESCRIPTION
This is a follow-up patch for [1]. When we are trying to add the VectorMask query implementation for Arm NEON, we found the jtreg tests for `VectorMask.trueCount/firstTrue/lastTrue` is not effective. The tests failure cannot be reported as expected. The main reason is that the Vector API methods are not hot enough to be compiled by C2 compiler. Wrap the main test codes inside a loop can make the tests effective.

With the tests taking effect, we can see a JVM crash due to the following assertion:
```
  vector/src/hotspot/share/opto/vectornode.hpp:879), pid=168241, tid=168257
  # Error: assert(mask->Opcode() == Op_VectorStoreMask) failed
```
The mask input might be other vector nodes like `"LoadVectorNode"`, since there is an optimization for `"VectorStoreMask"`:
```
  VectorStoreMask (VectorLoadMask value) ==> value
```
Changing the code to check whether its element basic type is `"T_BOOLEAN"` is more reasonable.

[1] https://bugs.openjdk.java.net/browse/JDK-8256973

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269568](https://bugs.openjdk.java.net/browse/JDK-8269568): JVM crashes when running VectorMask query tests


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to 8e3fcfaef51b2f555fec4bbe7eb53412696f8555
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**) ⚠️ Review applies to 8e3fcfaef51b2f555fec4bbe7eb53412696f8555
 * [Jatin Bhateja](https://openjdk.java.net/census#jbhateja) (@jatin-bhateja - Committer)
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Contributors
 * Sandhya Viswanathan `<sviswanathan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/168.diff">https://git.openjdk.java.net/jdk17/pull/168.diff</a>

</details>
