### PR TITLE
8269285: Crash/miscompile in CallGenerator::for_method_handle_inline after JDK-8191998

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1151,8 +1151,10 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
           const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
           const Type*       sig_type = TypeOopPtr::make_from_klass(signature->accessing_klass());
           if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-            const Type* recv_type = arg_type->join_speculative(sig_type); // keep speculative part
-            Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, recv_type));
+            // Keep the speculative part, but disallow it to empty the type
+            const Type* recv_type = arg_type->join_speculative(sig_type);
+            const Type* cast_type = recv_type->empty() ? sig_type : recv_type;
+            Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, cast_type));
             kit.set_argument(0, cast_obj);
           }
         }
@@ -1164,8 +1166,10 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
             const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
             const Type*       sig_type = TypeOopPtr::make_from_klass(t->as_klass());
             if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-              const Type* narrowed_arg_type = arg_type->join_speculative(sig_type); // keep speculative part
-              Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, narrowed_arg_type));
+              // Keep the speculative part, but disallow it to empty the type
+              const Type* narrowed_arg_type = arg_type->join_speculative(sig_type);
+              const Type* cast_type = narrowed_arg_type->empty() ? sig_type : narrowed_arg_type;
+              Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, cast_type));
               kit.set_argument(receiver_skip + j, cast_obj);
             }
           }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1151,7 +1151,7 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
           const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
           const Type*       sig_type = TypeOopPtr::make_from_klass(signature->accessing_klass());
           if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-            const Type* recv_type = arg_type->filter_speculative(sig_type); // keep speculative parts
+            const Type* recv_type = arg_type->filter_speculative(sig_type); // keep speculative part
             Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, recv_type));
             kit.set_argument(0, cast_obj);
           }
@@ -1164,7 +1164,7 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
             const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
             const Type*       sig_type = TypeOopPtr::make_from_klass(t->as_klass());
             if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-              const Type* narrowed_arg_type = arg_type->filter_speculative(sig_type); // keep speculative parts
+              const Type* narrowed_arg_type = arg_type->filter_speculative(sig_type); // keep speculative part
               Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, narrowed_arg_type));
               kit.set_argument(receiver_skip + j, cast_obj);
             }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1148,13 +1148,10 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
         // Cast receiver to its type.
         if (!target->is_static()) {
           Node* arg = kit.argument(0);
-          ciKlass* sig_klass = signature->accessing_klass();
           const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
-          const Type*       sig_type = TypeOopPtr::make_from_klass(sig_klass);
+          const Type*       sig_type = TypeOopPtr::make_from_klass(signature->accessing_klass());
           if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-            // Keep the speculative part, but do not join with interfaces
-            const Type* recv_type = sig_klass->is_interface() ?
-                    sig_type : arg_type->join_speculative(sig_type);
+            const Type* recv_type = arg_type->filter_speculative(sig_type); // keep speculative parts
             Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, recv_type));
             kit.set_argument(0, cast_obj);
           }
@@ -1164,13 +1161,10 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
           ciType* t = signature->type_at(i);
           if (t->is_klass()) {
             Node* arg = kit.argument(receiver_skip + j);
-            ciKlass* sig_klass = t->as_klass();
             const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
-            const Type*       sig_type = TypeOopPtr::make_from_klass(sig_klass);
+            const Type*       sig_type = TypeOopPtr::make_from_klass(t->as_klass());
             if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-              // Keep the speculative part, but do not join with interfaces
-              const Type* narrowed_arg_type = sig_klass->is_interface() ?
-                      sig_type : arg_type->join_speculative(sig_type);
+              const Type* narrowed_arg_type = arg_type->filter_speculative(sig_type); // keep speculative parts
               Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, narrowed_arg_type));
               kit.set_argument(receiver_skip + j, cast_obj);
             }

--- a/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
+++ b/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269285
+ * @summary Crash/miscompile in CallGenerator::for_method_handle_inline after JDK-8191998
+ * @requires vm.compMode == "Xmixed" & vm.flavor == "server"
+ *
+ * @run main/othervm
+ *        -Xcomp -Xbatch
+ *        compiler.types.TestMethodHandleSpeculation
+ */
+
+package compiler.types;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+public class TestMethodHandleSpeculation {
+
+    public static void main(String... args) {
+        byte[] serObj = {1};
+        MyClass<byte[]> obj = new MyClass<>();
+        for (int i = 0; i < 100_000; i++) {
+            boolean test = obj.test(serObj);
+            if (test) {
+                throw new IllegalStateException("Cannot be null");
+            }
+        }
+    }
+
+    static class MyClass<V extends Serializable> {
+        boolean test(V obj) {
+            Supplier<Boolean> supp = () -> (obj == null);
+            return supp.get();
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
+++ b/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
@@ -28,7 +28,7 @@
  * @requires vm.compMode == "Xmixed" & vm.flavor == "server"
  *
  * @run main/othervm
- *        -Xcomp -Xbatch
+ *        -Xcomp -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.types.TestMethodHandleSpeculation::main
  *        compiler.types.TestMethodHandleSpeculation
  */
 


### PR DESCRIPTION
See the bug report for more details.

I believe the [JDK-8191998](https://bugs.openjdk.java.net/browse/JDK-8191998) change introduced a slight regression, where the speculative type join may empty the type. It would then crash on assert in `fastdebug` builds, or miscompile the null-check to `true` in `release` bits. New test captures both failure modes.

This is not a recent regression, but a regression nevertheless, so I would like to have that fix in JDK 17. Please review carefully, or speak up if you want to move it to JDK 18+ and then backport later.

Additional testing:
 - [x] New test fails without the patch, passes with it
 - [x] Linux x86_64 `fastdebug` `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269285](https://bugs.openjdk.java.net/browse/JDK-8269285): Crash/miscompile in CallGenerator::for_method_handle_inline after JDK-8191998


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to 86b6f2cfa19356ffb505296531749171833d10aa
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 02e01bbd93717110f39ef4c57b6ea7deeeb82171


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/169.diff">https://git.openjdk.java.net/jdk17/pull/169.diff</a>

</details>
