### PR TITLE
8268884: C2: Compile::remove_speculative_types must iterate top-down

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4579,10 +4579,11 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
           modified++;
         }
       }
-      uint max = n->len();
-      for( uint i = 0; i < max; ++i ) {
-        Node *m = n->in(i);
-        if (not_a_node(m))  continue;
+      for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+        Node *m = n->fast_out(i);
+        if (not_a_node(m)) {
+          continue;
+        }
         worklist.push(m);
       }
     }
@@ -4603,10 +4604,11 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
         t = n->as_Type()->type();
         assert(t == t->remove_speculative(), "no more speculative types");
       }
-      uint max = n->len();
-      for( uint i = 0; i < max; ++i ) {
-        Node *m = n->in(i);
-        if (not_a_node(m))  continue;
+      for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+        Node *m = n->fast_out(i);
+        if (not_a_node(m)) {
+          continue;
+        }
         worklist.push(m);
       }
     }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4579,6 +4579,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
           modified++;
         }
       }
+      // Iterate over outs - endless loops is unreachable from below
       for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
         Node *m = n->fast_out(i);
         if (not_a_node(m)) {
@@ -4604,6 +4605,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
         t = n->as_Type()->type();
         assert(t == t->remove_speculative(), "no more speculative types");
       }
+      // Iterate over outs - endless loops is unreachable from below
       for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
         Node *m = n->fast_out(i);
         if (not_a_node(m)) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1740,7 +1740,7 @@ PhaseCCP::~PhaseCCP() {
 
 #ifdef ASSERT
 static bool ccp_type_widens(const Type* t, const Type* t0) {
-  assert(t->meet(t0) == t, "Not monotonic");
+  assert(t->meet_speculative(t0) == t, "Not monotonic");
   switch (t->base() == t0->base() ? t->base() : Type::Top) {
   case Type::Int:
     assert(t0->isa_int()->_widen <= t->isa_int()->_widen, "widen increases");

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1740,7 +1740,7 @@ PhaseCCP::~PhaseCCP() {
 
 #ifdef ASSERT
 static bool ccp_type_widens(const Type* t, const Type* t0) {
-  assert(t->meet_speculative(t0) == t, "Not monotonic");
+  assert(t->meet(t0) == t, "Not monotonic");
   switch (t->base() == t0->base() ? t->base() : Type::Top) {
   case Type::Int:
     assert(t0->isa_int()->_widen <= t->isa_int()->_widen, "widen increases");


### PR DESCRIPTION
Hi,

The test fails on "assert(t->meet(t0) == t) failed: Not monotonic" in PhaseCCP for a CheckCastPPNode. The test is really simple. The CheckCastPP is hanging of the ParmNode for the 'this' pointer. The user of this is a call, with an infinite empty loop, that gets inlined. The loop will have a safepoint that keeps the JVM State - the CheckCastPP is kept alive by that SafePointNode.

The assert triggers because the type for the CheckCastPP has a speculative part. In the assert "assert(t->meet(t0) == t) failed: Not monotonic" - t is the type evaluated for the CheckCastPP, t0 is the previous type (from _types map), which has not been updated yet and is still Type::Top. 

t->meet(t0) will drop the speculative part and fail the comparison.

Suggested fix - change meet to meet_specualtive that will keep the speculative part.

Please review,
Best regards,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268884](https://bugs.openjdk.java.net/browse/JDK-8268884): C2: Compile::remove_speculative_types must iterate top-down


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to eaa80ffac0c28b18e640adf769f79d80c13aa8c4
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/170.diff">https://git.openjdk.java.net/jdk17/pull/170.diff</a>

</details>
