### PR TITLE
8269528: VectorAPI Long512VectorTest fails on X86 KNL target

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -142,7 +142,7 @@ public:
   void evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask, XMMRegister src1, XMMRegister src2, int comparison, int vector_len);
   void evpblend(BasicType typ, XMMRegister dst, KRegister kmask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);
 
-  void load_vector_mask(XMMRegister dst, XMMRegister src, int vlen_in_bytes, BasicType elem_bt);
+  void load_vector_mask(XMMRegister dst, XMMRegister src, int vlen_in_bytes, BasicType elem_bt, bool is_legacy);
   void load_iota_indices(XMMRegister dst, Register scratch, int vlen_in_bytes);
 
   // vector compare

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7454,7 +7454,8 @@ instruct cmpvptest_anytrue_evex(rFlagsReg cr, legVec src1, legVec src2, immI_0 z
 
 //------------------------------------- LoadMask --------------------------------------------
 
-instruct loadMask(vec dst, vec src) %{
+instruct loadMask(legVec dst, legVec src) %{
+  predicate(!VM_Version::supports_avx512vlbw());
   match(Set dst (VectorLoadMask src));
   effect(TEMP dst);
   format %{ "vector_loadmask_byte $dst,$src\n\t" %}
@@ -7462,7 +7463,21 @@ instruct loadMask(vec dst, vec src) %{
     int vlen_in_bytes = vector_length_in_bytes(this);
     BasicType elem_bt = vector_element_basic_type(this);
 
-    __ load_vector_mask($dst$$XMMRegister, $src$$XMMRegister, vlen_in_bytes, elem_bt);
+    __ load_vector_mask($dst$$XMMRegister, $src$$XMMRegister, vlen_in_bytes, elem_bt, true);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct loadMask_evex(vec dst, vec src) %{
+  predicate(VM_Version::supports_avx512vlbw());
+  match(Set dst (VectorLoadMask src));
+  effect(TEMP dst);
+  format %{ "vector_loadmask_byte $dst,$src\n\t" %}
+  ins_encode %{
+    int vlen_in_bytes = vector_length_in_bytes(this);
+    BasicType elem_bt = vector_element_basic_type(this);
+
+    __ load_vector_mask($dst$$XMMRegister, $src$$XMMRegister, vlen_in_bytes, elem_bt, false);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
Long512VectorTest shows assertion failure on fastdebug build and incorrectness issue in release build.

Problem is seen on targets missing AVX512BW feature, load_vector_mask operation loads the mask boolean array into a vector followed by signed expansion operation to match the vector width of the operation. 

load_vector_mask macro assembly routine uses a vpsubb instruction which necessities existence of AVX512BW feature while operating over 64 byte operands.

Load mask over Byte512 and Short512 species does not get intrinsified since Matcher::match_rule_supported_vector
check for legality of vector size against the maximum vector size supported by the target, in case of 64 byte subword type operation, an AVX512 target must support AVX512BW feature else vector size is reduced to 32 bytes. 

For a load mask operation over all other species i.e. Int512,Float512,Double512,Long512 underlined mask boolean array is 16 bytes or less, thus a 256bit AVX2 byte vpsubb should suffice, also subsequent unpacking instruction (VPMOVSD, VPMOVSQ) needs AVX512F feature.

legVec register class constrains the allocation set of operands of new loadmask instruction pattern for non-AVX512BW targets to lower register bank ([X/Y]MM0-15 registers).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269528](https://bugs.openjdk.java.net/browse/JDK-8269528): VectorAPI Long512VectorTest fails on X86 KNL target


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/174.diff">https://git.openjdk.java.net/jdk17/pull/174.diff</a>

</details>
