### PR TITLE
8267602: [macos] [lanai] java/awt/PrintJob/Text/stringwidth.sh doesn't exit on cancelling print dialog

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -85,7 +85,6 @@
     }
 
     if (self.nextDrawableCount != 0) {
-        [self stopDisplayLink];
         return;
     }
     @autoreleasepool {

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -80,15 +80,18 @@
 - (void) blitTexture {
     if (self.ctx == NULL || self.javaLayer == NULL || self.buffer == nil || self.ctx.device == nil) {
         J2dTraceLn4(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: uninitialized (mtlc=%p, javaLayer=%p, buffer=%p, devide=%p)", self.ctx, self.javaLayer, self.buffer, ctx.device);
+        [self stopDisplayLink];
         return;
     }
 
     if (self.nextDrawableCount != 0) {
+        [self stopDisplayLink];
         return;
     }
     @autoreleasepool {
         if ((self.buffer.width == 0) || (self.buffer.height == 0)) {
             J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: cannot create drawable of size 0");
+            [self stopDisplayLink];
             return;
         }
 
@@ -99,17 +102,20 @@
 
         if (src_h <= 0 || src_w <= 0) {
            J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: Invalid src width or height.");
+           [self stopDisplayLink];
            return;
         }
 
         id<MTLCommandBuffer> commandBuf = [self.ctx createBlitCommandBuffer];
         if (commandBuf == nil) {
             J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: commandBuf is null");
+            [self stopDisplayLink];
             return;
         }
         id<CAMetalDrawable> mtlDrawable = [self nextDrawable];
         if (mtlDrawable == nil) {
             J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: nextDrawable is null)");
+            [self stopDisplayLink];
             return;
         }
         self.nextDrawableCount++;
@@ -277,6 +283,7 @@ Java_sun_java2d_metal_MTLLayer_blitTexture
     MTLContext * ctx = layer.ctx;
     if (layer == NULL || ctx == NULL) {
         J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer_blit : Layer or Context is null");
+        [layer stopDisplayLink];
         return;
     }
 


### PR DESCRIPTION
Final blit operation in MTLLayer.blitTexture() is driven by CVDisplayLink in Metal.
In this test case we are hitting an invalid condition because of which we exit from MTLLayer.blitTexture(), but we are not stopping the CVDisplayLink. This is causing the CVDisplayLink callback to run in loop. Fix is to stop CVDisplayLink when we return without completing final blit operation in MTLLayer.blitTexture().

Sanity and performance analysis is green. More details in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267602](https://bugs.openjdk.java.net/browse/JDK-8267602): [macos] [lanai] java/awt/PrintJob/Text/stringwidth.sh doesn't exit on cancelling print dialog


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/175.diff">https://git.openjdk.java.net/jdk17/pull/175.diff</a>

</details>
