### PR TITLE
8269269: [macos11] SystemIconTest fails with ClassCastException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,6 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
-javax/swing/JFileChooser/FileSystemView/SystemIconTest.java 8268280 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
@@ -72,9 +72,20 @@ public class SystemIconTest {
 
     static void testSystemIcon(File file, boolean implComplete) {
         int[] sizes = new int[] {16, 32, 48, 64, 128};
-        for (int size : sizes) {
-            ImageIcon icon = (ImageIcon) fsv.getSystemIcon(file, size, size);
+        if (!file.exists() || !file.canRead()) {
+            System.err.println("File " + file.getAbsolutePath() + " is inaccessible");
+            return;
+        }
 
+        for (int size : sizes) {
+            Icon i = fsv.getSystemIcon(file, size, size);
+            if (!(i instanceof ImageIcon)) {
+                // Default UI resource icon returned - it is not covered
+                // by new implementation so we can not test it
+                continue;
+            }
+
+            ImageIcon icon = (ImageIcon) i;
             //Enable below to see the icon
             //JLabel label = new JLabel(icon);
             //JOptionPane.showMessageDialog(null, label);
@@ -92,11 +103,12 @@ public class SystemIconTest {
                 MultiResolutionImage mri = (MultiResolutionImage) icon.getImage();
                 if (mri.getResolutionVariant(size, size) == null) {
                     throw new RuntimeException("There is no suitable variant for the size "
-                            + size + " in the multi resolution icon");
+                            + size + " in the multi resolution icon " + file.getAbsolutePath());
                 }
             } else {
                 if (implComplete) {
-                    throw new RuntimeException("icon is supposed to be multi-resolution but it is not");
+                    throw new RuntimeException("icon for " +
+                     file.getAbsolutePath() + " is supposed to be multi-resolution but it is not");
                 }
             }
         }

--- a/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
+++ b/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 /**
  * @test
  * @bug 8189604 8208702
+ * @requires !vm.debug | os.family != "windows"
  * @run main/othervm -Djava.awt.headless=false HangDuringStaticInitialization
  * @run main/othervm -Djava.awt.headless=true HangDuringStaticInitialization
  */


### PR DESCRIPTION
8268280: javax/swing/JFileChooser/FileSystemView/SystemIconTest.java fails on windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8269269](https://bugs.openjdk.java.net/browse/JDK-8269269): [macos11] SystemIconTest fails with ClassCastException
 * ⚠️ Failed to retrieve information on issue `8268280`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/176.diff">https://git.openjdk.java.net/jdk17/pull/176.diff</a>

</details>
