### PR TITLE
8269269: [macos11] SystemIconTest fails with ClassCastException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,6 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
-javax/swing/JFileChooser/FileSystemView/SystemIconTest.java 8268280 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 8182043
- * @key headful
  * @summary Access to Windows Large Icons
  * @run main SystemIconTest
  */
@@ -73,10 +72,6 @@ public class SystemIconTest {
 
     static void testSystemIcon(File file, boolean implComplete) {
         int[] sizes = new int[] {16, 32, 48, 64, 128};
-        if (!file.exists() || !file.canRead()) {
-            System.err.println("File " + file.getAbsolutePath() + " is inaccessible");
-            return;
-        }
 
         for (int size : sizes) {
             Icon i = fsv.getSystemIcon(file, size, size);
@@ -92,12 +87,13 @@ public class SystemIconTest {
             //JOptionPane.showMessageDialog(null, label);
 
             if (icon == null) {
-                throw new RuntimeException("icon is null!!!");
+                throw new RuntimeException(file.getAbsolutePath() + " icon is null!!!");
             }
 
             if (implComplete && icon.getIconWidth() != size) {
                 throw new RuntimeException("Wrong icon size " +
-                        icon.getIconWidth() + " when requested " + size);
+                        icon.getIconWidth() + " when requested " + size +
+                        " for file " + file.getAbsolutePath());
             }
 
             if (icon.getImage() instanceof MultiResolutionImage) {
@@ -105,11 +101,6 @@ public class SystemIconTest {
                 if (mri.getResolutionVariant(size, size) == null) {
                     throw new RuntimeException("There is no suitable variant for the size "
                             + size + " in the multi resolution icon " + file.getAbsolutePath());
-                }
-            } else {
-                if (implComplete) {
-                    throw new RuntimeException("icon for " +
-                     file.getAbsolutePath() + " is supposed to be multi-resolution but it is not");
                 }
             }
         }

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8182043
+ * @key headful
  * @summary Access to Windows Large Icons
  * @run main SystemIconTest
  */

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
@@ -72,9 +72,20 @@ public class SystemIconTest {
 
     static void testSystemIcon(File file, boolean implComplete) {
         int[] sizes = new int[] {16, 32, 48, 64, 128};
-        for (int size : sizes) {
-            ImageIcon icon = (ImageIcon) fsv.getSystemIcon(file, size, size);
+        if (!file.exists() || !file.canRead()) {
+            System.err.println("File " + file.getAbsolutePath() + " is inaccessible");
+            return;
+        }
 
+        for (int size : sizes) {
+            Icon i = fsv.getSystemIcon(file, size, size);
+            if (!(i instanceof ImageIcon)) {
+                // Default UI resource icon returned - it is not covered
+                // by new implementation so we can not test it
+                continue;
+            }
+
+            ImageIcon icon = (ImageIcon) i;
             //Enable below to see the icon
             //JLabel label = new JLabel(icon);
             //JOptionPane.showMessageDialog(null, label);
@@ -92,11 +103,12 @@ public class SystemIconTest {
                 MultiResolutionImage mri = (MultiResolutionImage) icon.getImage();
                 if (mri.getResolutionVariant(size, size) == null) {
                     throw new RuntimeException("There is no suitable variant for the size "
-                            + size + " in the multi resolution icon");
+                            + size + " in the multi resolution icon " + file.getAbsolutePath());
                 }
             } else {
                 if (implComplete) {
-                    throw new RuntimeException("icon is supposed to be multi-resolution but it is not");
+                    throw new RuntimeException("icon for " +
+                     file.getAbsolutePath() + " is supposed to be multi-resolution but it is not");
                 }
             }
         }


### PR DESCRIPTION
Added check for the icon class type
Added check if file or folder we are testing against exists and
accessible
Removed test from problem list

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8269269](https://bugs.openjdk.java.net/browse/JDK-8269269): [macos11] SystemIconTest fails with ClassCastException
 * [JDK-8269637](https://bugs.openjdk.java.net/browse/JDK-8269637): javax/swing/JFileChooser/FileSystemView/SystemIconTest.java fails on windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/178.diff">https://git.openjdk.java.net/jdk17/pull/178.diff</a>

</details>
