### PR TITLE
8269656: The test test/langtools/tools/javac/versions/Versions.java has duplicate test cycles

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -136,7 +136,7 @@ public class Versions {
             String target = st.target();
             boolean dotOne = st.dotOne();
             check_source_target(dotOne, List.of(classFileVer, target, target));
-            for (int j = i; j > 0; j--) {
+            for (int j = i - 1; j >= 0; j--) {
                 String source = sourceTargets[j].target();
                 check_source_target(dotOne, List.of(classFileVer, source, target));
             }
@@ -155,7 +155,7 @@ public class Versions {
                 st.checksrc(this, List.of("-source 1." + st.target(), "-target 1." + st.target()));
             }
 
-            if (i == sourceTargets.length) {
+            if (i == sourceTargets.length - 1) {
                 // Can use -target without -source setting only for
                 // most recent target since the most recent source is
                 // the default.


### PR DESCRIPTION
The test "test test/langtools/tools/javac/versions/Versions.java" duplicates some operations, while missing some others.

From the execution log:

...
test: check_source_target 52.0 8 8
...
test: check_source_target 52.0 8 8
...
test: check_source_target 53.0 9 9
...
test: check_source_target 53.0 9 9
...


We can notice the duplicates. Also some combinations are missed out. For example, "check -source 7 -target 8" is an expected combination in the output, but it is missed.

I have updated the index boundaries of the inner for-loop to address this discrepancy.

In addition, the test code contains an unreachable block of code, that causes the combination "most recent target" without a "-source" specifier to be missed out. I have updated the corresponding "if" condition too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269656](https://bugs.openjdk.java.net/browse/JDK-8269656): The test test/langtools/tools/javac/versions/Versions.java has duplicate test cycles


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/179.diff">https://git.openjdk.java.net/jdk17/pull/179.diff</a>

</details>
