### PR TITLE
8266595: jdk/jfr/jcmd/TestJcmdDump.java with slowdebug bits fails with AttachNotSupportedException

### DIFF
--- a/test/jdk/jdk/jfr/jcmd/TestJcmdDump.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdDump.java
@@ -33,8 +33,10 @@ import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
@@ -53,9 +55,9 @@ public class TestJcmdDump {
 
     private static final String[] names = { null, "r1" };
     private static final boolean booleanValues[] = { true, false };
+    private static final long timeoutMillis = 50000;
 
     public static void main(String[] args) throws Exception {
-
         // Create a stopped recording in the repository to complicate things
         Recording r = new Recording();
         r.start();
@@ -105,8 +107,15 @@ public class TestJcmdDump {
             leakList.add(new Object[1000_0000]);
             System.gc(); // This will shorten time for object to be emitted.
             File recording = new File("TestJCMdDump.jfr");
-            String[] params = buildParameters(pathToGCRoots, name, recording);
-            OutputAnalyzer output = JcmdHelper.jcmd(params);
+            List<String> params = buildParameters(pathToGCRoots, name, recording);
+            System.out.println(params);
+            OutputAnalyzer output = ProcessTools.executeProcess(new ProcessBuilder(params));
+            System.out.println("---------------- stdout ----------------");
+            System.out.println(output.getStdout());
+            System.out.println("---------------- stderr ----------------");
+            System.out.println(output.getStderr());
+            System.out.println("----------------------------------------");
+            System.out.println();
             JcmdAsserts.assertRecordingDumpedToFile(output, recording);
             int rootCount = 0;
             int oldObjectCount = 0;
@@ -155,8 +164,11 @@ public class TestJcmdDump {
         }
     }
 
-    private static String[] buildParameters(Boolean pathToGCRoots, String name, File recording) {
+    private static List<String> buildParameters(Boolean pathToGCRoots, String name, File recording) {
         List<String> params = new ArrayList<>();
+        params.add(JDKToolFinder.getJDKTool("jcmd"));
+        params.add("-J-Dsun.tools.attach.attachTimeout=" + timeoutMillis);
+        params.add(String.valueOf(ProcessHandle.current().pid()));
         params.add("JFR.dump");
         params.add("filename=" + recording.getAbsolutePath());
         if (pathToGCRoots != null) { // if path-to-gc-roots is omitted, default is used (disabled).
@@ -165,6 +177,6 @@ public class TestJcmdDump {
         if (name != null) { // if name is omitted, all recordings will be dumped
             params.add("name=" + name);
         }
-        return params.toArray(new String[0]);
+        return params;
     }
 }

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdDump.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdDump.java
@@ -110,12 +110,7 @@ public class TestJcmdDump {
             List<String> params = buildParameters(pathToGCRoots, name, recording);
             System.out.println(params);
             OutputAnalyzer output = ProcessTools.executeProcess(new ProcessBuilder(params));
-            System.out.println("---------------- stdout ----------------");
-            System.out.println(output.getStdout());
-            System.out.println("---------------- stderr ----------------");
-            System.out.println(output.getStderr());
-            System.out.println("----------------------------------------");
-            System.out.println();
+            output.reportDiagnosticSummary();
             JcmdAsserts.assertRecordingDumpedToFile(output, recording);
             int rootCount = 0;
             int oldObjectCount = 0;


### PR DESCRIPTION
Hi,

Could I have a review of a test fix that increases the timeout for attach. 

The test times out when running with slowdebug. I can reproduce the issue locally when running with the default 10 000 ms, but it works fine with 20 000 ms. I set the timeout to 50 000 ms, so attach at least have a chance to timeout, making it perhaps somewhat easier to analyze failures in the future (to rule timeout due to other reasons).

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266595](https://bugs.openjdk.java.net/browse/JDK-8266595): jdk/jfr/jcmd/TestJcmdDump.java with slowdebug bits fails with AttachNotSupportedException


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer) ⚠️ Review applies to 7ae464888644f5b9d7ff0d624d7075f863545d16
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 7ae464888644f5b9d7ff0d624d7075f863545d16


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/180.diff">https://git.openjdk.java.net/jdk17/pull/180.diff</a>

</details>
