### PR TITLE
JDK-8262841: Clarify the behavior of PhantomReference::refersTo

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -43,6 +43,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * <p> In order to ensure that a reclaimable object remains so, the referent of
  * a phantom reference may not be retrieved: The {@code get} method of a
  * phantom reference always returns {@code null}.
+ * The {@link #refersTo(Object) refersTo} method can be used to test
+ * whether some object is the referent of a phantom reference.
  *
  * @author   Mark Reinhold
  * @since    1.2
@@ -75,9 +77,7 @@ public class PhantomReference<T> extends Reference<T> {
      * is registered with the given queue.
      *
      * <p> It is possible to create a phantom reference with a {@code null}
-     * queue, but such a reference is completely useless: Its {@code get}
-     * method will always return {@code null} and, since it does not have a queue,
-     * it will never be enqueued.
+     * queue.  Such a reference will never be enqueued.
      *
      * @param referent the object the new phantom reference will refer to
      * @param q the queue with which the reference is to be registered,


### PR DESCRIPTION
`Reference::refersTo` behaves the same for soft, weak, and phantom references whereas `PhantomReference::get` always returns `null` which is different than soft and weak references. 

This patch clarifies the specification of `PhantomReference` to make it clear that `refersTo` can be used for phantom references.  With `refersTo`, phantom references if not registered in a reference queue are not completely useless.  Update the javadoc of the constructor to reflect that.

I created a CSR to document this spec clarification:
   https://bugs.openjdk.java.net/browse/JDK-8269688

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262841](https://bugs.openjdk.java.net/browse/JDK-8262841): Clarify the behavior of PhantomReference::refersTo


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/181.diff">https://git.openjdk.java.net/jdk17/pull/181.diff</a>

</details>
