### PR TITLE
8269704: Typo in j.t.Normalizer.normalize()

### DIFF
--- a/src/java.base/share/classes/java/text/Normalizer.java
+++ b/src/java.base/share/classes/java/text/Normalizer.java
@@ -144,7 +144,7 @@ public final class Normalizer {
     /**
      * Normalize a sequence of char values.
      * The sequence will be normalized according to the specified normalization
-     * from.
+     * form.
      * @param src        The sequence of char values to normalize.
      * @param form       The normalization form; one of
      *                   {@link java.text.Normalizer.Form#NFC},


### PR DESCRIPTION
A trivial typo fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269704](https://bugs.openjdk.java.net/browse/JDK-8269704): Typo in j.t.Normalizer.normalize()


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/187.diff">https://git.openjdk.java.net/jdk17/pull/187.diff</a>

</details>
