### PR TITLE
6766844: ByteArrayInputStream#read with a byte array of length 0 not consistent with InputStream when at EOF

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,6 +155,10 @@ public class ByteArrayInputStream extends InputStream {
      * {@code buf[pos+k-1]} are copied into {@code b[off]} through
      * {@code b[off+k-1]} in the manner performed by {@code System.arraycopy}.
      * The value {@code k} is added into {@code pos} and {@code k} is returned.
+     * <p>
+     * Unlike the {@link InputStream#read(byte[],int,int) overridden method}
+     * of {@code InputStream}, this method returns {@code -1} instead of zero
+     * if the end of the stream has been reached and {@code len == 0}.
      * <p>
      * This {@code read} method cannot block.
      *

--- a/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
@@ -51,10 +51,10 @@ public class ReadAllReadNTransferTo {
         ByteArrayInputStream bais = new ByteArrayInputStream(buf);
         bais.readAllBytes();
         if (bais.read(new byte[0]) != -1) {
-            throw new RuntimeException("read(byte[]) did not return 0");
+            throw new RuntimeException("read(byte[]) did not return -1");
         }
         if (bais.read(new byte[1], 0, 0) != -1) {
-            throw new RuntimeException("read(byte[],int,int) did not return 0");
+            throw new RuntimeException("read(byte[],int,int) did not return -1");
         }
 
         bais = new ByteArrayInputStream(buf, position, size);

--- a/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import jdk.test.lib.RandomFactory;
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @run main ReadAllReadNTransferTo
- * @bug 8180451
+ * @bug 6766844 8180451
  * @summary Verify ByteArrayInputStream readAllBytes, readNBytes, and transferTo
  * @key randomness
  */
@@ -48,8 +48,16 @@ public class ReadAllReadNTransferTo {
         int position = random.nextInt(SIZE/2);
         int size = random.nextInt(SIZE - position);
 
-        ByteArrayInputStream bais =
-            new ByteArrayInputStream(buf, position, size);
+        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+        bais.readAllBytes();
+        if (bais.read(new byte[0]) != -1) {
+            throw new RuntimeException("read(byte[]) did not return 0");
+        }
+        if (bais.read(new byte[1], 0, 0) != -1) {
+            throw new RuntimeException("read(byte[],int,int) did not return 0");
+        }
+
+        bais = new ByteArrayInputStream(buf, position, size);
         int off = size < 2 ? 0 : random.nextInt(size / 2);
         int len = size - off < 1 ? 0 : random.nextInt(size - off);
 
@@ -72,7 +80,6 @@ public class ReadAllReadNTransferTo {
             throw new RuntimeException("readAllBytes content");
         }
 
-        // XXX transferTo()
         bais = new ByteArrayInputStream(buf);
         ByteArrayOutputStream baos = new ByteArrayOutputStream(buf.length);
         if (bais.transferTo(baos) != buf.length) {


### PR DESCRIPTION
Modify the specification of `java.io.ByteArrayInputStream#read(byte[],int,int)` to indicate that `-1` is returned instead of `0` when the stream is at its end and the third parameter, `len`, is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6766844](https://bugs.openjdk.java.net/browse/JDK-6766844): ByteArrayInputStream#read with a byte array of length 0 not consistent with InputStream when at EOF


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/189.diff">https://git.openjdk.java.net/jdk17/pull/189.diff</a>

</details>
