### PR TITLE
JDK-8269722: NPE in HtmlDocletWriter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -75,6 +75,7 @@ import com.sun.source.doctree.StartElementTree;
 import com.sun.source.doctree.SummaryTree;
 import com.sun.source.doctree.SystemPropertyTree;
 import com.sun.source.doctree.TextTree;
+import com.sun.source.util.DocTreePath;
 import com.sun.source.util.SimpleDocTreeVisitor;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -1520,9 +1521,16 @@ public class HtmlDocletWriter {
 
                 @Override
                 public Boolean visitErroneous(ErroneousTree node, Content c) {
-                    messages.warning(ch.getDocTreePath(node),
-                            "doclet.tag.invalid_usage", node);
-                    result.add(new RawHtml(node.toString()));
+                    DocTreePath dtp = ch.getDocTreePath(node);
+                    if (dtp != null) {
+                        String body = node.getBody();
+                        if (body.matches("(?i)\\{@[a-z]+.*")) {
+                            messages.warning(dtp,"doclet.tag.invalid_usage", body);
+                        } else {
+                            messages.warning(dtp, "doclet.tag.invalid_input", body);
+                        }
+                    }
+                    result.add(Text.of(node.toString()));
                     return false;
                 }
 
@@ -1547,7 +1555,10 @@ public class HtmlDocletWriter {
                 public Boolean visitLink(LinkTree node, Content c) {
                     var inTags = context.inTags;
                     if (inTags.contains(LINK) || inTags.contains(LINK_PLAIN) || inTags.contains(SEE)) {
-                        messages.warning(ch.getDocTreePath(node), "doclet.see.nested_link", "{@" + node.getTagName() + "}");
+                        DocTreePath dtp = ch.getDocTreePath(node);
+                        if (dtp != null) {
+                            messages.warning(dtp, "doclet.see.nested_link", "{@" + node.getTagName() + "}");
+                        }
                         Content label = commentTagsToContent(node, element, node.getLabel(), context);
                         if (label.isEmpty()) {
                             label = Text.of(node.getReference().getSignature());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -104,6 +104,7 @@ doclet.see.class_or_package_not_found=Tag {0}: reference not found: {1}
 doclet.see.class_or_package_not_accessible=Tag {0}: reference not accessible: {1}
 doclet.see.nested_link=Tag {0}: nested link
 doclet.tag.invalid_usage=invalid usage of tag {0}
+doclet.tag.invalid_input=invalid input: ''{0}''
 doclet.Deprecated_API=Deprecated API
 doclet.Deprecated_Elements=Deprecated {0}
 doclet.Deprecated_In_Release=Deprecated in {0}

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 8268549
- * @summary Verify error reporting on inherited tags
+ * @bug 8269722
+ * @summary NPE in HtmlDocletWriter, reporting errors on inherited tags
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build toolbox.ToolBox javadoc.tester.*

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268549
+ * @summary Verify error reporting on inherited tags
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestInherited
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestInherited extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestInherited tester = new TestInherited();
+        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    @Test
+    public void testBadInheritedParam(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                public class BadParam {
+                    public static class Base {
+                        /**
+                         * @param i a < b
+                         */
+                        public void m(int i) { }
+                    }
+                                
+                    public static class Sub extends Base {
+                        public void m(int i) { }
+                    }
+                }
+                """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-Xdoclint:-missing", "-XDdoe",
+                src.resolve("BadParam.java").toString());
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void testBadInheritedReturn(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                public class BadReturn {
+                    public static class Base {
+                        /**
+                         * @return  a < b
+                         */
+                        public int m() { }
+                    }
+                                
+                    public static class Sub extends Base {
+                        public int m() { }
+                    }
+                }
+                """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-Xdoclint:-missing",
+                src.resolve("BadReturn.java").toString());
+        checkExit(Exit.OK);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -56,7 +56,7 @@ public class TestInherited extends JavadocTester {
                          */
                         public void m(int i) { }
                     }
-                                
+
                     public static class Sub extends Base {
                         public void m(int i) { }
                     }
@@ -80,7 +80,7 @@ public class TestInherited extends JavadocTester {
                          */
                         public int m() { }
                     }
-                                
+
                     public static class Sub extends Base {
                         public int m() { }
                     }

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -374,7 +374,7 @@ public class TestJavaFX extends JavadocTester {
         checkExit(Exit.OK);
 
         // make sure the doclet indeed emits the warning
-        checkOutput(Output.OUT, true, "C.java:31: warning: invalid usage of tag <");
+        checkOutput(Output.OUT, true, "C.java:31: warning: invalid input: '<'");
     }
 
     /*

--- a/test/langtools/jdk/javadoc/doclet/testNonInlineHtmlTagRemoval/TestNonInlineHtmlTagRemoval.java
+++ b/test/langtools/jdk/javadoc/doclet/testNonInlineHtmlTagRemoval/TestNonInlineHtmlTagRemoval.java
@@ -85,6 +85,6 @@ public class TestNonInlineHtmlTagRemoval extends JavadocTester {
 
         checkOutput("Negative.html", true,
                 """
-                    <div class="block">case1: A hanging &lt;  : xx<</div>""");
+                    <div class="block">case1: A hanging &lt;  : xx&lt;</div>""");
     }
 }


### PR DESCRIPTION
Please review a workaround/fix for an NPE in HtmlDocletWriter.

The underlying problem is triggered by having a method with no comment override a method with bad/malformed comments. That is then handled poorly in `HtmlDocletWriter.commentTagsToContent` which uses an incorrect `CommentHelper`.

The workaround fix is to check for a null `DocTreePath` from `CommentHelper.getDocTreePath`, and to suppress printing the error message in that case.  The error message will typically have been generated for the bad comments in the super type, so dropping the message is not such a bad thing anyway.

The diagnostic is improved by using a new/different message when the node does not seem to be tag-related.  In addition, the erroneous text is presented "as text" and not "as raw HTML".   These changes affect a couple of otherwise unrelated tests.

A new test is added, that exercises the conditions that gave rise to the NPE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269722](https://bugs.openjdk.java.net/browse/JDK-8269722): NPE in HtmlDocletWriter


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/190.diff">https://git.openjdk.java.net/jdk17/pull/190.diff</a>

</details>
