### PR TITLE
8269771: assert(tmp == _callprojs.fallthrough_catchproj) failed: allocation control projection

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -963,11 +963,12 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc) {
         assert(init->outcnt() <= 2, "only a control and memory projection expected");
         Node *ctrl_proj = init->proj_out_or_null(TypeFunc::Control);
         if (ctrl_proj != NULL) {
-#ifdef ASSERT
-          Node* tmp = init->in(TypeFunc::Control);
-          assert(tmp == _callprojs.fallthrough_catchproj, "allocation control projection");
-#endif
           _igvn.replace_node(ctrl_proj, init->in(TypeFunc::Control));
+#ifdef ASSERT
+          // If the InitializeNode has no memory out, it will die, and tmp will become NULL
+          Node* tmp = init->in(TypeFunc::Control);
+          assert(tmp == NULL || tmp == _callprojs.fallthrough_catchproj, "allocation control projection");
+#endif
         }
         Node *mem_proj = init->proj_out_or_null(TypeFunc::Memory);
         if (mem_proj != NULL) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -963,11 +963,11 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc) {
         assert(init->outcnt() <= 2, "only a control and memory projection expected");
         Node *ctrl_proj = init->proj_out_or_null(TypeFunc::Control);
         if (ctrl_proj != NULL) {
-          _igvn.replace_node(ctrl_proj, init->in(TypeFunc::Control));
 #ifdef ASSERT
           Node* tmp = init->in(TypeFunc::Control);
           assert(tmp == _callprojs.fallthrough_catchproj, "allocation control projection");
 #endif
+          _igvn.replace_node(ctrl_proj, init->in(TypeFunc::Control));
         }
         Node *mem_proj = init->proj_out_or_null(TypeFunc::Memory);
         if (mem_proj != NULL) {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3313,7 +3313,8 @@ MemBarNode* MemBarNode::make(Compile* C, int opcode, int atp, Node* pn) {
 
 void MemBarNode::remove(PhaseIterGVN *igvn) {
   if (outcnt() != 2) {
-    return;
+    assert(Opcode() == Op_Initialize, "Only seen when there are no use of init memory");
+    assert(outcnt() == 1, "Only control then");
   }
   if (trailing_store() || trailing_load_store()) {
     MemBarNode* leading = leading_membar();
@@ -3322,8 +3323,12 @@ void MemBarNode::remove(PhaseIterGVN *igvn) {
       leading->remove(igvn);
     }
   }
-  igvn->replace_node(proj_out(TypeFunc::Memory), in(TypeFunc::Memory));
-  igvn->replace_node(proj_out(TypeFunc::Control), in(TypeFunc::Control));
+  if (proj_out_or_null(TypeFunc::Memory) != NULL) { 
+    igvn->replace_node(proj_out(TypeFunc::Memory), in(TypeFunc::Memory));
+  }
+  if (proj_out_or_null(TypeFunc::Control) != NULL) {
+    igvn->replace_node(proj_out(TypeFunc::Control), in(TypeFunc::Control));
+  }
 }
 
 //------------------------------Ideal------------------------------------------

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3323,7 +3323,7 @@ void MemBarNode::remove(PhaseIterGVN *igvn) {
       leading->remove(igvn);
     }
   }
-  if (proj_out_or_null(TypeFunc::Memory) != NULL) { 
+  if (proj_out_or_null(TypeFunc::Memory) != NULL) {
     igvn->replace_node(proj_out(TypeFunc::Memory), in(TypeFunc::Memory));
   }
   if (proj_out_or_null(TypeFunc::Control) != NULL) {


### PR DESCRIPTION
When I investigated this bug I found out it was already fixed by JDK-8268405, or at least - it didn't happen any more. Since I had a good reproducer I took a look at why it happened and found two issues.

The noteable thing about the test case is that there are still allocations that isn't used. The initalizeNode lead to HaltNodes. This looks like a temporary state while the graph is simplified.

1) In macro.cpp - process_users_of_allocation - there was an assert that was wrong. We must assert before the replace_node - otherwise tmp will always be NULL and fail. Why this hasn't happened before is a mystery.

2) memnode.cpp - MemBarNode::remove - returns without doing anything if there are not exactly 2 outs. In this case there is a InitalizeNode that leads to a HaltNode. The memory uses has been removed - so the memory projection from the InitalizeNode is already removed.

If you want to check if this patch fixes the issue - you need to sync to jdk-17+26 - or before the fix for JDK-8268405.

Please review,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269771](https://bugs.openjdk.java.net/browse/JDK-8269771): assert(tmp == _callprojs.fallthrough_catchproj) failed: allocation control projection


### Reviewers
 * [Rickard Bäckman](https://openjdk.java.net/census#rbackman) (@rickard - **Reviewer**) ⚠️ Review applies to 75336a9e5aeb9a6f62e29a4bfd0108a828aa2eb4
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/193.diff">https://git.openjdk.java.net/jdk17/pull/193.diff</a>

</details>
