### PR TITLE
8269745: [JVMCI] restore original qualified exports to Graal

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -27,6 +27,12 @@ module jdk.internal.vm.ci {
     exports jdk.vm.ci.services to
         jdk.internal.vm.compiler,
         jdk.internal.vm.compiler.management;
+    exports jdk.vm.ci.runtime to
+        jdk.internal.vm.compiler,
+        jdk.internal.vm.compiler.management;
+    exports jdk.vm.ci.meta to jdk.internal.vm.compiler;
+    exports jdk.vm.ci.code to jdk.internal.vm.compiler;
+    exports jdk.vm.ci.hotspot to jdk.internal.vm.compiler;
 
     uses jdk.vm.ci.services.JVMCIServiceLocator;
     uses jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;


### PR DESCRIPTION
The changes to src/jdk.internal.vm.ci/share/classes/module-info.java in [8267112](https://bugs.openjdk.java.net/browse/JDK-8267112) broke the use case of running Graal-optimized Truffle on OracleJDK: [RunOnJDK](https://www.graalvm.org/reference-manual/js/RunOnJDK/).

Restoring the qualified JVMCI exports resolves this problem.

Tested: tier1 which runs jvmci tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269745](https://bugs.openjdk.java.net/browse/JDK-8269745): [JVMCI] restore original qualified exports to Graal


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/196.diff">https://git.openjdk.java.net/jdk17/pull/196.diff</a>

</details>
