### PR TITLE
8269802: javac fails to compile nested pattern matching switches

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -469,6 +469,8 @@ public class TransPatterns extends TreeTranslator {
                         currentValue = prevCurrentValue;
                         bindingContext.pop();
                     }
+                } else {
+                    c.stats = translate(c.stats);
                 }
                 if (enumSwitch) {
                     var labels = c.labels;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -386,6 +386,7 @@ public class TransPatterns extends TreeTranslator {
                     hasNullCase = true;
                 }
             }
+            selector = translate(selector);
             statements.append(make.at(tree.pos).VarDef(temp, !hasNullCase ? attr.makeNullCheck(selector)
                                                                           : selector));
             VarSymbol index = new VarSymbol(Flags.SYNTHETIC,

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -22,12 +22,13 @@
  */
 
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896
+ * @bug 8262891 8268333 8268896 8269802
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -66,6 +67,10 @@ public class Switches {
         npeTest(this::npeTestExpression);
         exhaustiveStatementSane("");
         exhaustiveStatementSane(null);
+        switchNestingTest(this::switchNestingStatementStatement);
+        switchNestingTest(this::switchNestingStatementExpression);
+        switchNestingTest(this::switchNestingExpressionStatement);
+        switchNestingTest(this::switchNestingExpressionExpression);
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -117,6 +122,13 @@ public class Switches {
         } catch (NullPointerException ex) {
             //OK
         }
+    }
+
+    void switchNestingTest(BiFunction<Object, Object, String> testCase) {
+        assertEquals("string, string", testCase.apply("", ""));
+        assertEquals("string, other", testCase.apply("", 1));
+        assertEquals("other, string", testCase.apply(1, ""));
+        assertEquals("other, other", testCase.apply(1, 1));
     }
 
     int typeTestPatternSwitchTest(Object o) {
@@ -364,6 +376,88 @@ public class Switches {
         switch (o) {
             case Object obj, null:; //no break intentionally - should not fall through to any possible default
         }
+    }
+
+    String switchNestingStatementStatement(Object o1, Object o2) {
+        switch (o1) {
+            case String s1 -> {
+                switch (o2) {
+                    case String s2 -> {
+                        return "string, string";
+                    }
+                    default -> {
+                        return "string, other";
+                    }
+                }
+            }
+            default -> {
+                switch (o2) {
+                    case String s2 -> {
+                        return "other, string";
+                    }
+                    default -> {
+                        return "other, other";
+                    }
+                }
+            }
+        }
+    }
+
+    String switchNestingStatementExpression(Object o1, Object o2) {
+        switch (o1) {
+            case String s1 -> {
+                return switch (o2) {
+                    case String s2 -> "string, string";
+                    default -> "string, other";
+                };
+            }
+            default -> {
+                return switch (o2) {
+                    case String s2 -> "other, string";
+                    default -> "other, other";
+                };
+            }
+        }
+    }
+
+    String switchNestingExpressionStatement(Object o1, Object o2) {
+        return switch (o1) {
+            case String s1 -> {
+                switch (o2) {
+                    case String s2 -> {
+                        yield "string, string";
+                    }
+                    default -> {
+                        yield "string, other";
+                    }
+                }
+            }
+            default -> {
+                switch (o2) {
+                    case String s2 -> {
+                        yield "other, string";
+                    }
+                    default -> {
+                        yield "other, other";
+                    }
+                }
+            }
+        };
+    }
+
+    String switchNestingExpressionExpression(Object o1, Object o2) {
+        return switch (o1) {
+            case String s1 ->
+                switch (o2) {
+                    case String s2 -> "string, string";
+                    default -> "string, other";
+                };
+            default ->
+                switch (o2) {
+                    case String s2 -> "other, string";
+                    default -> "other, other";
+                };
+        };
     }
 
     //verify that for cases like:

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802
+ * @bug 8262891 8268333 8268896 8269802 8269808
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -71,6 +71,7 @@ public class Switches {
         switchNestingTest(this::switchNestingStatementExpression);
         switchNestingTest(this::switchNestingExpressionStatement);
         switchNestingTest(this::switchNestingExpressionExpression);
+        switchNestingTest(this::switchNestingIfSwitch);
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -458,6 +459,31 @@ public class Switches {
                     default -> "other, other";
                 };
         };
+    }
+
+    String switchNestingIfSwitch(Object o1, Object o2) {
+        BiFunction<Object, Object, String> f = (n1, n2) -> {
+            if (o1 instanceof CharSequence cs) {
+                return switch (cs) {
+                    case String s1 ->
+                        switch (o2) {
+                            case String s2 -> "string, string";
+                            default -> "string, other";
+                        };
+                    default ->
+                        switch (o2) {
+                            case String s2 -> "other, string";
+                            default -> "other, other";
+                        };
+                };
+            } else {
+                return switch (o2) {
+                            case String s2 -> "other, string";
+                            default -> "other, other";
+                        };
+            }
+        };
+        return f.apply(o1, o2);
     }
 
     //verify that for cases like:


### PR DESCRIPTION
There are two places which where `TransPatterns` is mistakenly not translating a subtree: the statements for non-pattern cases, and the selector. This PR is fixing that by translating the statements and selector.

/issue JDK-8269808

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8269802](https://bugs.openjdk.java.net/browse/JDK-8269802): javac fails to compile nested pattern matching switches
 * [JDK-8269808](https://bugs.openjdk.java.net/browse/JDK-8269808): javac generates class with invalid stack map


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/203.diff">https://git.openjdk.java.net/jdk17/pull/203.diff</a>

</details>
