### PR TITLE
JDK-8249634: doclint should report implicit constructor as missing javadoc comments

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -182,10 +182,18 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                 reportMissing("dc.missing.comment");
                 return null;
             }
+
+
+
         } else {
             if (tree == null) {
-                if (!isSynthetic() && !isOverridingMethod)
+                if (isDefaultConstructor()) {
+                    if (isNormalClass(p.getParentPath())) {
+                        reportMissing("dc.default.constructor");
+                    }
+                } else if (!isOverridingMethod) {
                     reportMissing("dc.missing.comment");
+                }
                 return null;
             }
         }
@@ -1142,7 +1150,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                 || env.types.isAssignable(t, env.java_lang_RuntimeException));
     }
 
-    private boolean isSynthetic() {
+    private boolean isDefaultConstructor() {
         switch (env.currElement.getKind()) {
             case CONSTRUCTOR:
                 // A synthetic default constructor has the same pos as the
@@ -1151,6 +1159,14 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                 return env.getPos(p) == env.getPos(p.getParentPath());
         }
         return false;
+    }
+
+    private boolean isNormalClass(TreePath p) {
+        return switch (p.getLeaf().getKind()) {
+            case ENUM, RECORD -> false;
+            case CLASS -> true;
+            default -> throw new IllegalArgumentException(p.getLeaf().getKind().name());
+        };
     }
 
     void markEnclosingTag(Flag flag) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/resources/doclint.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/resources/doclint.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ dc.attr.table.border.not.number = invalid value for attribute "border": {0}
 dc.attr.unknown = unknown attribute: {0}
 dc.bad.option = bad option: {0}
 dc.bad.value.for.option = bad value for option: {0} {1}
+dc.default.constructor = use of default constructor, which does not provide a comment
 dc.empty = no description for @{0}
 dc.entity.invalid = invalid entity &{0};
 dc.exception.not.thrown = exception not thrown: {0}

--- a/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
+++ b/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
@@ -62,6 +62,7 @@ public class TestDiagsLineCaret extends JavadocTester {
                 "-XDaccessInternalAPI",
                 "-tagletpath", testClasses,
                 "-taglet", "MyTaglet",
+                "-Xdoclint:none",
                 "MyClass.java");
         checkExit(Exit.ERROR);
 

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -420,7 +420,7 @@ public class TestJavaFX extends JavadocTester {
                 "--javafx",
                 "--disable-javafx-strict-checks",
                 "--no-platform-links",
-                "-Xdoclint:all",
+                "-Xdoclint:all,-missing",
                 "--source-path", "src5",
                 "pkg");
         checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/doclet/testMissingComment/TestMissingComment.java
+++ b/test/langtools/jdk/javadoc/doclet/testMissingComment/TestMissingComment.java
@@ -49,11 +49,13 @@ public class TestMissingComment extends JavadocTester {
     public void testClass(Path base) throws Exception {
         test(base.resolve("class"), """
                     // no doc comment
-                    public class C { }
+                    public class C { 
+                        /** . */ C() { }
+                    }
                     """,
                 """
                     testClass/class/src/C.java:2: warning: no comment
-                    public class C { }
+                    public class C {
                            ^
                     """);
     }
@@ -65,6 +67,7 @@ public class TestMissingComment extends JavadocTester {
                     public class C {
                         // no doc comment
                         public void m() { }
+                        /** . */ C() { }
                     }
                     """,
                 """
@@ -81,6 +84,7 @@ public class TestMissingComment extends JavadocTester {
                     public class C {
                         // no doc comment
                         public int f;
+                        /** . */ C() { }
                     }
                     """,
                 """
@@ -96,12 +100,15 @@ public class TestMissingComment extends JavadocTester {
                     /** Class comment. */
                     public class C {
                         // no doc comment
-                        public class Nested { }
+                        public class Nested { 
+                            /** . */ Nested() { }
+                        }
+                        /** . */ C() { }
                     }
                     """,
                 """
                     testNested/nest/src/C.java:4: warning: no comment
-                        public class Nested { }
+                        public class Nested {
                                ^
                     """);
     }

--- a/test/langtools/jdk/javadoc/tool/doclint/DocLintTest.java
+++ b/test/langtools/jdk/javadoc/tool/doclint/DocLintTest.java
@@ -63,7 +63,7 @@ public class DocLintTest {
 
     final String code =
         /* 01 */    "/** Class comment. */\n" +
-        /* 02 */    "public class Test {\n" +
+        /* 02 */    "public class Test { /** */ Test() { }\n" +
         /* 03 */    "    /** Method comment. */\n" +
         /* 04 */    "    public void method() { }\n" +
         /* 05 */    "\n" +
@@ -85,14 +85,14 @@ public class DocLintTest {
 
     final String p1Code =
         /* 01 */    "package p1;\n" +
-        /* 02 */    "public class P1Test {\n" +
+        /* 02 */    "public class P1Test { /** */ P1Test() { }\n" +
         /* 03 */    "    /** Syntax < error. */\n" +
         /* 04 */    "    public void method() { }\n" +
         /* 05 */    "}\n";
 
     final String p2Code =
         /* 01 */    "package p2;\n" +
-        /* 02 */    "public class P2Test {\n" +
+        /* 02 */    "public class P2Test { /** */ P2Test() { }\n" +
         /* 03 */    "    /** Syntax < error. */\n" +
         /* 04 */    "    public void method() { }\n" +
         /* 05 */    "}\n";

--- a/test/langtools/tools/doclint/AccessTest.java
+++ b/test/langtools/tools/doclint/AccessTest.java
@@ -19,7 +19,7 @@
  */
 
 /** */
-public class AccessTest {
+public class AccessTest { /** */ AccessTest() { }
     /**
      * public a < b
      */
@@ -42,7 +42,7 @@ public class AccessTest {
 }
 
 /** */
-class AccessTest2 {
+class AccessTest2 { /** */ AccessTest2() { }
     /**
      * public a < b
      */

--- a/test/langtools/tools/doclint/AccessibilityTest.java
+++ b/test/langtools/tools/doclint/AccessibilityTest.java
@@ -4,8 +4,8 @@
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-accessibility AccessibilityTest.java
- * @run main DocLintTester -ref AccessibilityTest.out AccessibilityTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-accessibility AccessibilityTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref AccessibilityTest.out AccessibilityTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/AnchorTest.java
+++ b/test/langtools/tools/doclint/AnchorTest.java
@@ -4,7 +4,7 @@
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref AnchorTest.out AnchorTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref AnchorTest.out AnchorTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/AnchorTest2.java
+++ b/test/langtools/tools/doclint/AnchorTest2.java
@@ -4,8 +4,8 @@
  * @summary doclint doesn't reset HTML anchors correctly
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref AnchorTest2.out AnchorTest2.java AnchorTest2a.java
- * @run main DocLintTester -ref AnchorTest2.out AnchorTest2a.java AnchorTest2.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref AnchorTest2.out AnchorTest2.java AnchorTest2a.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref AnchorTest2.out AnchorTest2a.java AnchorTest2.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/CustomTagTest.java
+++ b/test/langtools/tools/doclint/CustomTagTest.java
@@ -17,5 +17,6 @@
  * @unknownTag Text for an unknown tag.
  */
 public class CustomTagTest {
+    /** */ CustomTagTest() { }
 }
 

--- a/test/langtools/tools/doclint/DuplicateParamTest.java
+++ b/test/langtools/tools/doclint/DuplicateParamTest.java
@@ -4,8 +4,8 @@
  * @summary Validate parameter names uniqueness
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-reference DuplicateParamTest.java
- * @run main DocLintTester -ref DuplicateParamTest.out DuplicateParamTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-reference DuplicateParamTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref DuplicateParamTest.out DuplicateParamTest.java
  */
 
 /** . */

--- a/test/langtools/tools/doclint/DuplicateReturnTest.java
+++ b/test/langtools/tools/doclint/DuplicateReturnTest.java
@@ -4,8 +4,8 @@
  * @summary Validate return uniqueness
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-reference DuplicateReturnTest.java
- * @run main DocLintTester -ref DuplicateReturnTest.out DuplicateReturnTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-reference DuplicateReturnTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref DuplicateReturnTest.out DuplicateReturnTest.java
  */
 
 /** . */

--- a/test/langtools/tools/doclint/EmptyAuthorTest.java
+++ b/test/langtools/tools/doclint/EmptyAuthorTest.java
@@ -10,4 +10,5 @@
 
 /** @author */
 public class EmptyAuthorTest {
+    /** */ EmptyAuthorTest() { }
 }

--- a/test/langtools/tools/doclint/EmptyExceptionTest.java
+++ b/test/langtools/tools/doclint/EmptyExceptionTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptyExceptionTest {
+public class EmptyExceptionTest {  /** */ EmptyExceptionTest() { }
     /** @exception NullPointerException */
     void emptyException() throws NullPointerException { }
 }

--- a/test/langtools/tools/doclint/EmptyParamTest.java
+++ b/test/langtools/tools/doclint/EmptyParamTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptyParamTest {
+public class EmptyParamTest { /** . */ EmptyParamTest() { }
     /** @param i */
     void emptyParam(int i) { }
 }

--- a/test/langtools/tools/doclint/EmptyReturnTest.java
+++ b/test/langtools/tools/doclint/EmptyReturnTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptyReturnTest {
+public class EmptyReturnTest { /** . */ EmptyReturnTest() { }
     /** @return */
     int emptyReturn() { return 0; }
 }

--- a/test/langtools/tools/doclint/EmptySerialDataTest.java
+++ b/test/langtools/tools/doclint/EmptySerialDataTest.java
@@ -12,7 +12,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 /** . */
-public class EmptySerialDataTest implements Serializable {
+public class EmptySerialDataTest implements Serializable { /** . */ EmptySerialDataTest() { }
     /**
      * .
      * @serialData

--- a/test/langtools/tools/doclint/EmptySerialFieldTest.java
+++ b/test/langtools/tools/doclint/EmptySerialFieldTest.java
@@ -12,7 +12,7 @@ import java.io.ObjectStreamField;
 import java.io.Serializable;
 
 /** . */
-public class EmptySerialFieldTest implements Serializable {
+public class EmptySerialFieldTest implements Serializable { /** . */ EmptySerialFieldTest() { }
 
     /**
      * @serialField empty    String

--- a/test/langtools/tools/doclint/EmptySinceTest.java
+++ b/test/langtools/tools/doclint/EmptySinceTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptySinceTest {
+public class EmptySinceTest { /** . */ EmptySinceTest() { }
     /** @since */
     void emptySince() { }
 }

--- a/test/langtools/tools/doclint/EmptyTagsTest.java
+++ b/test/langtools/tools/doclint/EmptyTagsTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptyTagsTest {
+public class EmptyTagsTest { /** . */ EmptyTagsTest() { }
     /**
      * Comment. <p>
      */

--- a/test/langtools/tools/doclint/EmptyVersionTest.java
+++ b/test/langtools/tools/doclint/EmptyVersionTest.java
@@ -9,7 +9,7 @@
  */
 
 /** . */
-public class EmptyVersionTest {
+public class EmptyVersionTest { /** . */ EmptyVersionTest() { }
     /** @version */
     void missingVersion() { }
 }

--- a/test/langtools/tools/doclint/EndTagsTest.java
+++ b/test/langtools/tools/doclint/EndTagsTest.java
@@ -4,8 +4,8 @@
  * @summary doclint: structural issue hidden
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-html EndTagsTest.java
- * @run main DocLintTester -ref EndTagsTest.out EndTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-html EndTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref EndTagsTest.out EndTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/EndWithIdentifierTest.java
+++ b/test/langtools/tools/doclint/EndWithIdentifierTest.java
@@ -29,5 +29,8 @@ public class EndWithIdentifierTest {
 
     /**<a name*/
     private void attribute() {}
+
+    /** . */
+    EndWithIdentifierTest() { }
 }
 

--- a/test/langtools/tools/doclint/HtmlAttrsTest.java
+++ b/test/langtools/tools/doclint/HtmlAttrsTest.java
@@ -4,8 +4,8 @@
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-html HtmlAttrsTest.java
- * @run main DocLintTester -ref HtmlAttrsTest.out HtmlAttrsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-html HtmlAttrsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref HtmlAttrsTest.out HtmlAttrsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/HtmlTagsTest.java
+++ b/test/langtools/tools/doclint/HtmlTagsTest.java
@@ -4,8 +4,8 @@
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:-html HtmlTagsTest.java
- * @run main DocLintTester -ref HtmlTagsTest.out HtmlTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing,-html HtmlTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref HtmlTagsTest.out HtmlTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/LambdaTest.java
+++ b/test/langtools/tools/doclint/LambdaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary ignore declarations in lambda expressions
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:all SyntheticTest.java
+ * @run main DocLintTester -Xmsgs:all LambdaTest.java
  */
 
 package acme;
@@ -41,6 +41,8 @@ import java.util.function.Function;
  */
 public final class LambdaTest
 {
+    /** */ LambdaTest() { }
+
     /**
      * The field itself has docs.
      */

--- a/test/langtools/tools/doclint/LiteralTest.java
+++ b/test/langtools/tools/doclint/LiteralTest.java
@@ -14,4 +14,7 @@ public class LiteralTest {
 
     /** <code> abc {@code < & > } def </code> */
     public void bad_code_in_code() { }
+
+    /** */
+    LiteralTest() { }
 }

--- a/test/langtools/tools/doclint/MissingThrowsTest.java
+++ b/test/langtools/tools/doclint/MissingThrowsTest.java
@@ -12,4 +12,7 @@
 public class MissingThrowsTest {
     /** */
     void missingThrows() throws Exception { }
+
+    /** */
+    MissingThrowsTest() { }
 }

--- a/test/langtools/tools/doclint/MultipleDocLintOptionsTest.java
+++ b/test/langtools/tools/doclint/MultipleDocLintOptionsTest.java
@@ -9,4 +9,7 @@
 public class MultipleDocLintOptionsTest {
     /** @return */
     int emptyReturn() { return -1; }
+
+    /** */
+    MultipleDocLintOptionsTest() { }
 }

--- a/test/langtools/tools/doclint/NoArgsConstructorTest.java
+++ b/test/langtools/tools/doclint/NoArgsConstructorTest.java
@@ -1,0 +1,26 @@
+/*
+ * @test /nodynamiccopyright/
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs:-missing NoArgsConstructorTest.java
+ * @run main DocLintTester -Xmsgs:missing/protected -ref NoArgsConstructorTest.out NoArgsConstructorTest.java
+ */
+
+/** Main Comment. */
+public class NoArgsConstructorTest {
+    // default constructor
+
+    /** PublicConstructor comment. */
+    public static class PublicConstructor {
+        public PublicConstructor() { }
+    }
+
+    /** PrivateConstructor comment. */
+    public static class PrivateConstructor {
+        private PrivateConstructor() { }
+    }
+
+    /** PublicInterface comment. */
+    public interface PublicInterface {
+    }
+}

--- a/test/langtools/tools/doclint/NoArgsConstructorTest.out
+++ b/test/langtools/tools/doclint/NoArgsConstructorTest.out
@@ -1,0 +1,7 @@
+NoArgsConstructorTest.java:10: warning: use of default constructor, which does not provide a comment
+public class NoArgsConstructorTest {
+       ^
+NoArgsConstructorTest.java:15: warning: no comment
+        public PublicConstructor() { }
+               ^
+2 warnings

--- a/test/langtools/tools/doclint/OverridesTest.java
+++ b/test/langtools/tools/doclint/OverridesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,36 +59,43 @@ abstract class C1 {
      * @return an int
      */
     int m(int p) throws Exception;
+    /** . */ C1() { }
 }
 
 /** An implementing class. */
 class C2 implements I1 {
     int m(int  p) throws Exception { return p; }
+    /** . */ C2() { }
 }
 
 /** An extending class. */
 class C3 extends C1 {
     int m(int  p) throws Exception { return p; }
+    /** . */ C3() { }
 }
 
 /** An extending and implementing class. */
 class C4 extends C1 implements I1 {
     int m(int  p) throws Exception { return p; }
+    /** . */ C4() { }
 }
 
 /** An implementing class using inheritdoc. */
 class C5 implements I1 {
     /** {@inheritDoc} */
     int m(int  p) throws Exception { return p; }
+    /** . */ C5() { }
 }
 
 /** An implementing class with incomplete documentation. */
 class C6 implements I1 {
     /** Overriding method */
     int m(int  p) throws Exception { return p; }
+    /** . */ C6() { }
 }
 
 /** A class implementing an inherited interface. */
 class C7 implements I2 {
     int m(int  p) throws Exception { return p; }
+    /** . */ C7() { }
 }

--- a/test/langtools/tools/doclint/ParaTagTest.java
+++ b/test/langtools/tools/doclint/ParaTagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,4 +53,7 @@ public class ParaTagTest {
      * </pre>
      */
     public void z() {}
+
+    /** . */
+    ParaTagTest() { }
 }

--- a/test/langtools/tools/doclint/ProvidesTest.java
+++ b/test/langtools/tools/doclint/ProvidesTest.java
@@ -4,7 +4,7 @@
  * @summary Module summary page should display information based on "api" or "detail" mode.
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref ProvidesTest.out ProvidesTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref ProvidesTest.out ProvidesTest.java
  */
 
 /**

--- a/test/langtools/tools/doclint/ReferenceTest.java
+++ b/test/langtools/tools/doclint/ReferenceTest.java
@@ -18,7 +18,7 @@ public class ReferenceTest {
     /**
      * @param x description
      */
-    public class InvalidParam { }
+    public class InvalidParam { /** . */ private InvalidParam() { } }
 
     /**
      * @param x description
@@ -28,7 +28,7 @@ public class ReferenceTest {
     /**
      * @param <X> description
      */
-    public class typaram_name_not_found { }
+    public class typaram_name_not_found { /** . */ private typaram_name_not_found() { } }
 
     /**
      * @see Object#tooStrong()
@@ -75,5 +75,8 @@ public class ReferenceTest {
      * @see not.Found[]
      */
     public void invalid_array_types() { }
+
+    /** . */
+    private ReferenceTest() { }
 }
 

--- a/test/langtools/tools/doclint/SummaryTest.java
+++ b/test/langtools/tools/doclint/SummaryTest.java
@@ -16,4 +16,7 @@ public class SummaryTest {
 
     /** {@summary legal} text {@summary illegal} **/
     public void m2() {}
+
+    /** . */
+    private SummaryTest() { }
 }

--- a/test/langtools/tools/doclint/SyntaxTest.java
+++ b/test/langtools/tools/doclint/SyntaxTest.java
@@ -14,5 +14,8 @@ public class SyntaxTest {
      * a < b
      */
     public void syntax_error() { }
+
+    /** */
+    private SyntaxTest() { }
 }
 

--- a/test/langtools/tools/doclint/SyntheticTest.java
+++ b/test/langtools/tools/doclint/SyntheticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,22 @@
 
 /*
  * @test
- * @bug 8004832
+ * @bug 8004832 8249634
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs:all SyntheticTest.java
+ * @run main DocLintTester -Xmsgs:all -ref SyntheticTest.out SyntheticTest.java
  */
 
 /**
  * This is a test that messages are not generated for synthesized elements
- * such as default constructors and enum methods.
+ * such as enum methods, and that a message *is* generated for a default constructor
  */
 public class SyntheticTest {
     // No explicit constructor implies a default constructor
 
     /** enum E */
-    enum E {
+    public enum E {
         /** enum member E1 */
         E1,
         /** enum member E2 */

--- a/test/langtools/tools/doclint/SyntheticTest.out
+++ b/test/langtools/tools/doclint/SyntheticTest.out
@@ -1,0 +1,5 @@
+SyntheticTest.java:37: warning: use of default constructor, which does not provide a comment
+public class SyntheticTest {
+       ^
+1 warning
+

--- a/test/langtools/tools/doclint/UnfinishedInlineTagTest.java
+++ b/test/langtools/tools/doclint/UnfinishedInlineTagTest.java
@@ -14,5 +14,6 @@ import java.util.List;
 /**{@link List
  */
 public class UnfinishedInlineTagTest {
+    /** . */ private UnfinishedInlineTagTest() { }
 }
 

--- a/test/langtools/tools/doclint/UsesTest.java
+++ b/test/langtools/tools/doclint/UsesTest.java
@@ -4,7 +4,7 @@
  * @summary Module summary page should display information based on "api" or "detail" mode.
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref UsesTest.out UsesTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref UsesTest.out UsesTest.java
  */
 
 /**

--- a/test/langtools/tools/doclint/ValueTest.java
+++ b/test/langtools/tools/doclint/ValueTest.java
@@ -4,7 +4,7 @@
  * @summary doclint needs to check for valid usage of at-value tag
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref ValueTest.out ValueTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref ValueTest.out ValueTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/anchorTests/p/Test.java
+++ b/test/langtools/tools/doclint/anchorTests/p/Test.java
@@ -50,5 +50,11 @@ public class Test {
          * <a id="okMethod">okMethod again</a>
          */
         public void m() { }
+
+        /** . */
+        private Nested() { }
     }
+
+    /** . */
+    private Test() { }
 }

--- a/test/langtools/tools/doclint/html/HtmlVersionTagsAttrsTest.java
+++ b/test/langtools/tools/doclint/html/HtmlVersionTagsAttrsTest.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmaxerrs 200 -ref HtmlVersionTagsAttrsTest.out HtmlVersionTagsAttrsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -Xmaxerrs 200 -ref HtmlVersionTagsAttrsTest.out HtmlVersionTagsAttrsTest.java
  */
 
 /**

--- a/test/langtools/tools/doclint/html/InlineTagsTest.java
+++ b/test/langtools/tools/doclint/html/InlineTagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs -ref InlineTagTest.out InlineTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InlineTagTest.out InlineTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/html/ListTagsTest.java
+++ b/test/langtools/tools/doclint/html/ListTagsTest.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs -ref ListTagsTest.out ListTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref ListTagsTest.out ListTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/html/OtherTagsTest.java
+++ b/test/langtools/tools/doclint/html/OtherTagsTest.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs -ref OtherTagsTest.out OtherTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref OtherTagsTest.out OtherTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/html/TableTagsTest.java
+++ b/test/langtools/tools/doclint/html/TableTagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs -ref TableTagTest.out TableTagsTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref TableTagTest.out TableTagsTest.java
  */
 
 /** */

--- a/test/langtools/tools/doclint/html/TagNotAllowed.java
+++ b/test/langtools/tools/doclint/html/TagNotAllowed.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref TagNotAllowed.out TagNotAllowed.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref TagNotAllowed.out TagNotAllowed.java
  */
 
 /**

--- a/test/langtools/tools/doclint/html/TextNotAllowed.java
+++ b/test/langtools/tools/doclint/html/TextNotAllowed.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref TextNotAllowed.out TextNotAllowed.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref TextNotAllowed.out TextNotAllowed.java
  */
 
 /**

--- a/test/langtools/tools/doclint/html/UnknownTagTest.java
+++ b/test/langtools/tools/doclint/html/UnknownTagTest.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -Xmsgs -ref UnknownTagTest.out UnknownTagTest.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref UnknownTagTest.out UnknownTagTest.java
  */
 
 /**

--- a/test/langtools/tools/doclint/packageTests/bad/Test.java
+++ b/test/langtools/tools/doclint/packageTests/bad/Test.java
@@ -13,5 +13,7 @@
 package bad;
 
 /** */
-class Test { }
+class Test {
+    /** */ Test() { }
+}
 

--- a/test/langtools/tools/doclint/tidy/AnchorAlreadyDefined.java
+++ b/test/langtools/tools/doclint/tidy/AnchorAlreadyDefined.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref AnchorAlreadyDefined.out AnchorAlreadyDefined.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref AnchorAlreadyDefined.out AnchorAlreadyDefined.java
  */
 
 // tidy: Warning: <.*> anchor ".*" already defined

--- a/test/langtools/tools/doclint/tidy/BadEnd.java
+++ b/test/langtools/tools/doclint/tidy/BadEnd.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref BadEnd.out BadEnd.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref BadEnd.out BadEnd.java
  */
 
 // tidy: Warning: <.*> is probably intended as </.*>

--- a/test/langtools/tools/doclint/tidy/InsertImplicit.java
+++ b/test/langtools/tools/doclint/tidy/InsertImplicit.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref InsertImplicit.out InsertImplicit.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InsertImplicit.out InsertImplicit.java
  */
 
 // tidy: Warning: inserting implicit <.*>

--- a/test/langtools/tools/doclint/tidy/InvalidEntity.java
+++ b/test/langtools/tools/doclint/tidy/InvalidEntity.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref InvalidEntity.out InvalidEntity.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InvalidEntity.out InvalidEntity.java
  */
 
 // tidy: Warning: replacing invalid numeric character reference .*

--- a/test/langtools/tools/doclint/tidy/InvalidName.java
+++ b/test/langtools/tools/doclint/tidy/InvalidName.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref InvalidName.out InvalidName.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InvalidName.out InvalidName.java
  */
 
 // tidy: Warning: <a> cannot copy name attribute to id

--- a/test/langtools/tools/doclint/tidy/InvalidTag.java
+++ b/test/langtools/tools/doclint/tidy/InvalidTag.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref InvalidTag.out InvalidTag.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InvalidTag.out InvalidTag.java
  */
 
 // tidy: Error: <.*> is not recognized!

--- a/test/langtools/tools/doclint/tidy/InvalidURI.java
+++ b/test/langtools/tools/doclint/tidy/InvalidURI.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref InvalidURI.out InvalidURI.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref InvalidURI.out InvalidURI.java
  */
 
 // tidy: Warning: <a> escaping malformed URI reference

--- a/test/langtools/tools/doclint/tidy/MissingGT.java
+++ b/test/langtools/tools/doclint/tidy/MissingGT.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref MissingGT.out MissingGT.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref MissingGT.out MissingGT.java
  */
 
 // tidy: Warning: <.*> missing '>' for end of tag

--- a/test/langtools/tools/doclint/tidy/MissingTag.java
+++ b/test/langtools/tools/doclint/tidy/MissingTag.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref MissingTag.out MissingTag.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref MissingTag.out MissingTag.java
  */
 
 // tidy: Warning: missing <.*>

--- a/test/langtools/tools/doclint/tidy/NestedTag.java
+++ b/test/langtools/tools/doclint/tidy/NestedTag.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref NestedTag.out NestedTag.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref NestedTag.out NestedTag.java
  */
 
 // tidy: Warning: nested emphasis <.*>

--- a/test/langtools/tools/doclint/tidy/ParaInPre.java
+++ b/test/langtools/tools/doclint/tidy/ParaInPre.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref ParaInPre.out ParaInPre.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref ParaInPre.out ParaInPre.java
  */
 
 // tidy: Warning: replacing <p> by <br>

--- a/test/langtools/tools/doclint/tidy/RepeatedAttr.java
+++ b/test/langtools/tools/doclint/tidy/RepeatedAttr.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref RepeatedAttr.out RepeatedAttr.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref RepeatedAttr.out RepeatedAttr.java
  */
 
 // tidy: Warning: <.*> dropping value ".*" for repeated attribute ".*"

--- a/test/langtools/tools/doclint/tidy/TextNotAllowed.java
+++ b/test/langtools/tools/doclint/tidy/TextNotAllowed.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref TextNotAllowed.out TextNotAllowed.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref TextNotAllowed.out TextNotAllowed.java
  */
 
 // tidy: Warning: plain text isn't allowed in <.*> elements

--- a/test/langtools/tools/doclint/tidy/TrimmingEmptyTag.java
+++ b/test/langtools/tools/doclint/tidy/TrimmingEmptyTag.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref TrimmingEmptyTag.out TrimmingEmptyTag.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref TrimmingEmptyTag.out TrimmingEmptyTag.java
  */
 
 // tidy: Warning: trimming empty <.*>

--- a/test/langtools/tools/doclint/tidy/UnescapedOrUnknownEntity.java
+++ b/test/langtools/tools/doclint/tidy/UnescapedOrUnknownEntity.java
@@ -5,7 +5,7 @@
  * @library ..
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
- * @run main DocLintTester -ref UnescapedOrUnknownEntity.out UnescapedOrUnknownEntity.java
+ * @run main DocLintTester -Xmsgs:all,-missing -ref UnescapedOrUnknownEntity.out UnescapedOrUnknownEntity.java
  */
 
 // tidy: Warning: unescaped & or unknown entity ".*"

--- a/test/langtools/tools/doclint/tool/MaxDiagsTest.java
+++ b/test/langtools/tools/doclint/tool/MaxDiagsTest.java
@@ -19,4 +19,6 @@ public class MaxDiagsTest {
 
     /** 4 undocumented signature items */
     public int warnings(int a1, int a2) throws Exception { return 0; }
+
+    /** */ MaxDiagsTest() { }
 }

--- a/test/langtools/tools/doclint/tool/StatsTest.java
+++ b/test/langtools/tools/doclint/tool/StatsTest.java
@@ -17,4 +17,6 @@ public class StatsTest {
 
     /** 4 undocumented signature items */
     public int warnings(int a1, int a2) throws Exception { return 0; }
+
+    /** */ StatsTest() { }
 }

--- a/test/langtools/tools/javac/doclint/DocLintFormatTest.java
+++ b/test/langtools/tools/javac/doclint/DocLintFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class DocLintFormatTest {
         System.err.println("Test: " + file);
         List<String> output = new JavacTask(tb)
                   .outdir(classes)
-                  .options("-XDrawDiagnostics", "-Xdoclint")
+                  .options("-XDrawDiagnostics", "-Xdoclint:all,-missing")
                   .files(file)
                   .run(expect.length == 0 ? Task.Expect.SUCCESS : Task.Expect.FAIL)
                   .writeAll()

--- a/test/langtools/tools/javac/doclint/DocLintTest.java
+++ b/test/langtools/tools/javac/doclint/DocLintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class DocLintTest {
 
     final String code =
         /* 01 */    "/** Class comment. */\n" +
-        /* 02 */    "public class Test {\n" +
+        /* 02 */    "public class Test { /** */ Test() { }\n" +
         /* 03 */    "    /** Method comment. */\n" +
         /* 04 */    "    public void method() { }\n" +
         /* 05 */    "\n" +

--- a/test/langtools/tools/javac/doclint/IncludePackagesTest.java
+++ b/test/langtools/tools/javac/doclint/IncludePackagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,29 +63,39 @@ public class IncludePackagesTest {
 
     final String[] sources = new String[] {
         "p1/p1T.java",
-        "package p1;\n" +
-        "/** Syntax < error. */\n" +
-        "public class p1T {\n" +
-        "}\n",
+        """
+            package p1;
+            /** Syntax < error. */
+            public class p1T {
+            }
+            """,
         "p1/sp1/p1sp1T.java",
-        "package p1.sp1;\n" +
-        "/** Syntax < error. */\n" +
-        "public class p1sp1T {\n" +
-        "}\n",
+        """
+            package p1.sp1;
+            /** Syntax < error. */
+            public class p1sp1T {
+            }
+            """,
         "p1/sp1/sp2/p1sp1sp2T.java",
-        "package p1.sp1.sp2;\n" +
-        "/** Syntax < error. */\n" +
-        "public class p1sp1sp2T {\n" +
-        "}\n",
+        """
+            package p1.sp1.sp2;
+            /** Syntax < error. */
+            public class p1sp1sp2T {
+            }
+            """,
         "p2/p2T.java",
-        "package p2;\n" +
-        "/** Syntax < error. */\n" +
-        "public class p2T {\n" +
-        "}\n",
+        """
+            package p2;
+            /** Syntax < error. */
+            public class p2T {
+            }
+            """,
         "Default.java",
-        "/** Syntax < error. */\n" +
-        "public class Default {\n" +
-        "}\n",
+        """
+            /** Syntax < error. */
+            public class Default {
+            }
+            """,
     };
 
     final String rawDiags = "-XDrawDiagnostics";
@@ -130,28 +140,28 @@ public class IncludePackagesTest {
                 files.add(new JFOImpl(sources[si], sources[si + 1]));
             }
 
-            test(Arrays.asList(rawDiags, "-Xdoclint"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing"),
                     Main.Result.ERROR,
                     EnumSet.of(Message.p1T, Message.p1sp1T, Message.p1sp1sp2T,
                                Message.p2T, Message.Default));
 
-            test(Arrays.asList(rawDiags, "-Xdoclint", "-Xdoclint/package:p1"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing", "-Xdoclint/package:p1"),
                     Main.Result.ERROR,
                     EnumSet.of(Message.p1T));
 
-            test(Arrays.asList(rawDiags, "-Xdoclint", "-Xdoclint/package:p1.*"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing", "-Xdoclint/package:p1.*"),
                     Main.Result.ERROR,
                     EnumSet.of(Message.p1sp1T, Message.p1sp1sp2T));
 
-            test(Arrays.asList(rawDiags, "-Xdoclint", "-Xdoclint/package:p1.*,-p1.sp1"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing", "-Xdoclint/package:p1.*,-p1.sp1"),
                     Main.Result.ERROR,
                     EnumSet.of(Message.p1sp1sp2T));
 
-            test(Arrays.asList(rawDiags, "-Xdoclint", "-Xdoclint/package:-p1.sp1"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing", "-Xdoclint/package:-p1.sp1"),
                     Main.Result.ERROR,
                     EnumSet.of(Message.p1T, Message.p1sp1sp2T, Message.p2T, Message.Default));
 
-            test(Arrays.asList(rawDiags, "-Xdoclint", "-Xdoclint/package:wrong+package"),
+            test(Arrays.asList(rawDiags, "-Xdoclint:all,-missing", "-Xdoclint/package:wrong+package"),
                     Main.Result.CMDERR,
                     EnumSet.of(Message.INVALID_PACKAGE_ERROR));
 

--- a/test/langtools/tools/javac/doclint/NPEDuplicateClassNamesTest.java
+++ b/test/langtools/tools/javac/doclint/NPEDuplicateClassNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class NPEDuplicateClassNamesTest extends TestRunner {
                 "2 errors");
         List<String> output = new JavacTask(tb)
                   .outdir(classes)
-                  .options("-XDrawDiagnostics", "-Xdoclint:all", "-XDdev")
+                  .options("-XDrawDiagnostics", "-Xdoclint:all,-missing", "-XDdev")
                   .files(tb.findJavaFiles(src))
                   .run(Task.Expect.FAIL)
                   .writeAll()


### PR DESCRIPTION
Please review a simple update to doclint, to generate messages for the "effectively missing" comment on default constructors on "normal" classes (not enums classes or record classes.)

The change does affect a bunch of tests, mostly doclint tests, which all use atypical "toy" classes to host the comments to be tested, and which generally do not have explicit constructors ... and so trigger the new warning about using default constructors.

There is no one solution applied to all tests. The general theme of the changes is to minimize the changes, and in almost all cases to avoid changing any "golden files" or "expected output".

The following techniques are used to modify tests:

* where it does not significantly interact with other test options, disable the check for missing comments when that is not the primary function of the test
* where it would not affect any line numbers in any expected output, add an explicit no-args constructor at the end of the class body
* add an explicit no-args constructor on the same line as the opening `{` of the class body (i.e.in order not to change line numbers in reference output)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8249634](https://bugs.openjdk.java.net/browse/JDK-8249634): doclint should report implicit constructor as missing javadoc comments


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/204.diff">https://git.openjdk.java.net/jdk17/pull/204.diff</a>

</details>
