### PR TITLE
8269825: [TESTBUG] Missing testing for x86 KNL platforms

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -109,6 +109,9 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
           "Highest supported AVX instructions set on x86/x64")              \
           range(0, 99)                                                      \
                                                                             \
+  product(bool, UseKNLSetting, false, DIAGNOSTIC,                           \
+          "Control whether Knights platform setting should be used")        \
+                                                                            \
   product(bool, UseCLMUL, false,                                            \
           "Control whether CLMUL instructions can be used on x86/x64")      \
                                                                             \

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -769,6 +769,15 @@ void VM_Version::get_processor_features() {
       _features &= ~CPU_VZEROUPPER;
       _features &= ~CPU_AVX512BW;
       _features &= ~CPU_AVX512VL;
+      _features &= ~CPU_AVX512DQ;
+      _features &= ~CPU_AVX512_VNNI;
+      _features &= ~CPU_AVX512_VAES;
+      _features &= ~CPU_AVX512_VPOPCNTDQ;
+      _features &= ~CPU_AVX512_VPCLMULQDQ;
+      _features &= ~CPU_AVX512_VBMI;
+      _features &= ~CPU_AVX512_VBMI2;
+      _features &= ~CPU_CLWB;
+      _features &= ~CPU_FLUSHOPT;
     }
   }
 

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -778,7 +778,7 @@ public:
   static bool is_intel()          { assert_is_initialized(); return _cpuid_info.std_vendor_name_0 == 0x756e6547; } // 'uneG'
   static bool is_zx()             { assert_is_initialized(); return (_cpuid_info.std_vendor_name_0 == 0x746e6543) || (_cpuid_info.std_vendor_name_0 == 0x68532020); } // 'tneC'||'hS  '
   static bool is_atom_family()    { return ((cpu_family() == 0x06) && ((extended_cpu_model() == 0x36) || (extended_cpu_model() == 0x37) || (extended_cpu_model() == 0x4D))); } //Silvermont and Centerton
-  static bool is_knights_family() { return ((cpu_family() == 0x06) && ((extended_cpu_model() == 0x57) || (extended_cpu_model() == 0x85))); } // Xeon Phi 3200/5200/7200 and Future Xeon Phi
+  static bool is_knights_family() { return UseKNLSetting || ((cpu_family() == 0x06) && ((extended_cpu_model() == 0x57) || (extended_cpu_model() == 0x85))); } // Xeon Phi 3200/5200/7200 and Future Xeon Phi
 
   static bool supports_processor_topology() {
     return (_cpuid_info.std_max_function >= 0xB) &&


### PR DESCRIPTION
Knights family of X86 Intel CPU (KNL) does not support some of avx512 features (AVX512VL/BW) and have other restrictions. We may not have such kind of machines in our testing environment and may miss bugs as JBS history shows (look recent fixes for KNL).
On other hand we have some Windows VM instances which seem emulate KNL configuration and limit avx512 instructions on CPU which supports full set. Recent bug JDK-8269775 shows such example.
I suggest to add -XX:+UseKNLSetting x86 diagnostic flag to emulate KNL settings in HotSpot VM to test such configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269825](https://bugs.openjdk.java.net/browse/JDK-8269825): [TESTBUG] Missing testing for x86 KNL platforms


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to 9466fb97c61dccd49212119ad9d87c6b32939c7c
 * jbhateja - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/205.diff">https://git.openjdk.java.net/jdk17/pull/205.diff</a>

</details>
