### PR TITLE
8269185: Directories in /opt/runtimepackagetest and /path/to/jdk-17 are different

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -39,6 +39,8 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 %description
 APPLICATION_DESCRIPTION
 
+%global __os_install_post %{nil}
+
 %prep
 
 %build


### PR DESCRIPTION
Disable stripping to prevent rpmbuild from modifying executables

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269185](https://bugs.openjdk.java.net/browse/JDK-8269185): Directories in /opt/runtimepackagetest and /path/to/jdk-17 are different


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/207.diff">https://git.openjdk.java.net/jdk17/pull/207.diff</a>

</details>
