### PR TITLE
8269661: JNI_GetStringCritical does not lock char array

### DIFF
--- a/src/hotspot/share/gc/shared/stringdedup/stringDedup.hpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedup.hpp
@@ -147,7 +147,17 @@ public:
   // precondition: is_enabled()
   static void threads_do(ThreadClosure* tc);
 
+  // Marks the String as not being subject to deduplication.  This can be
+  // used to prevent deduplication of Strings whose value array must remain
+  // stable and cannot be replaced by a shared duplicate.  Must be called
+  // before obtaining the value array; this function provides an acquire
+  // barrier.
+  // precondition: is_enabled()
+  // precondition: java_string is a Java String object.
+  static void forbid_deduplication(oop java_string);
+
   // Notify that a String is being added to the StringTable.
+  // Implicity forbids deduplication of the String.
   // precondition: is_enabled()
   // precondition: java_string is a Java String object.
   static void notify_intern(oop java_string);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -44,6 +44,7 @@
 #include "compiler/compiler_globals.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
+#include "gc/shared/stringdedup/stringDedup.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jfr/support/jfrThreadId.hpp"
@@ -2842,19 +2843,45 @@ HOTSPOT_JNI_RELEASEPRIMITIVEARRAYCRITICAL_RETURN();
 JNI_END
 
 
+static typeArrayOop lock_gc_or_pin_string_value(JavaThread* thread, oop str) {
+  if (Universe::heap()->supports_object_pinning()) {
+    // Forbid deduplication before obtaining the value array, to prevent
+    // deduplication from replacing the value array while setting up or in
+    // the critical section.  That would lead to the release operation
+    // unpinning the wrong object.
+    if (StringDedup::is_enabled()) {
+      NoSafepointVerifier nsv;
+      StringDedup::forbid_deduplication(str);
+    }
+    typeArrayOop s_value = java_lang_String::value(str);
+    return (typeArrayOop) Universe::heap()->pin_object(thread, s_value);
+  } else {
+    Handle h(thread, str);      // Handlize across potential safepoint.
+    GCLocker::lock_critical(thread);
+    return java_lang_String::value(h());
+  }
+}
+
+static void unlock_gc_or_unpin_string_value(JavaThread* thread, oop str) {
+  if (Universe::heap()->supports_object_pinning()) {
+    typeArrayOop s_value = java_lang_String::value(str);
+    Universe::heap()->unpin_object(thread, s_value);
+  } else {
+    GCLocker::unlock_critical(thread);
+  }
+}
+
 JNI_ENTRY(const jchar*, jni_GetStringCritical(JNIEnv *env, jstring string, jboolean *isCopy))
   HOTSPOT_JNI_GETSTRINGCRITICAL_ENTRY(env, string, (uintptr_t *) isCopy);
-  oop s = lock_gc_or_pin_object(thread, string);
-  typeArrayOop s_value = java_lang_String::value(s);
-  bool is_latin1 = java_lang_String::is_latin1(s);
-  if (isCopy != NULL) {
-    *isCopy = is_latin1 ? JNI_TRUE : JNI_FALSE;
-  }
+  oop s = JNIHandles::resolve_non_null(string);
   jchar* ret;
-  if (!is_latin1) {
+  if (!java_lang_String::is_latin1(s)) {
+    typeArrayOop s_value = lock_gc_or_pin_string_value(thread, s);
     ret = (jchar*) s_value->base(T_CHAR);
+    if (isCopy != NULL) *isCopy = JNI_FALSE;
   } else {
     // Inflate latin1 encoded string to UTF16
+    typeArrayOop s_value = java_lang_String::value(s);
     int s_len = java_lang_String::length(s, s_value);
     ret = NEW_C_HEAP_ARRAY_RETURN_NULL(jchar, s_len + 1, mtInternal);  // add one for zero termination
     /* JNI Specification states return NULL on OOM */
@@ -2864,6 +2891,7 @@ JNI_ENTRY(const jchar*, jni_GetStringCritical(JNIEnv *env, jstring string, jbool
       }
       ret[s_len] = 0;
     }
+    if (isCopy != NULL) *isCopy = JNI_TRUE;
   }
  HOTSPOT_JNI_GETSTRINGCRITICAL_RETURN((uint16_t *) ret);
   return ret;
@@ -2872,15 +2900,16 @@ JNI_END
 
 JNI_ENTRY(void, jni_ReleaseStringCritical(JNIEnv *env, jstring str, const jchar *chars))
   HOTSPOT_JNI_RELEASESTRINGCRITICAL_ENTRY(env, str, (uint16_t *) chars);
-  // The str and chars arguments are ignored for UTF16 strings
   oop s = JNIHandles::resolve_non_null(str);
   bool is_latin1 = java_lang_String::is_latin1(s);
   if (is_latin1) {
     // For latin1 string, free jchar array allocated by earlier call to GetStringCritical.
     // This assumes that ReleaseStringCritical bookends GetStringCritical.
     FREE_C_HEAP_ARRAY(jchar, chars);
+  } else {
+    // For non-latin1 string, drop the associated gc-locker/pin.
+    unlock_gc_or_unpin_string_value(thread, s);
   }
-  unlock_gc_or_unpin_object(thread, str);
 HOTSPOT_JNI_RELEASESTRINGCRITICAL_RETURN();
 JNI_END
 


### PR DESCRIPTION
Please review this fix to jni_GetStringCritical.  When object pinning is
being used it pins/unpins the String argument, but that's the wrong object.
It should be pinning the associated byte array (when !latin1), as it is a
reference into that array that will be returned and must be imobilized.

Presently only Shenandoah is affected by this bug, as it is the only GC that
uses object pinning (at the region level) rather than the GC locker.  But
both G1 and ZGC plan to use object pinning in the future.  But with region
pinning the problem is still going to be rare because the String and its
value array are likely to be allocated in the same region.

In addition, if pinning the String's value array, we also need to prevent
string deduplication from changing the array while in the critical section.
Otherwise, the unpin when the critical section is released will use the
wrong object for the unpin operation.  We accomplish this by marking the
String as no longer subject to string deduplication.  As that state is
sticky, when pinning is used a String can't be deduplicated after being used
in a critical section.  We could add a critical section counter to String,
but for now we're going to guess that isn't worth the effort.  (String has
at least 2 bytes available for the two string deduplication flags plus such
a counter (more in some configurations, but always at least 2 at present)).

As part of the restructuring to accomplish these changes, it proved to be
easy to avoid using the GC locker (or pinning) for the latin1 case, where a
copy of the value array will be used.  Hence this change also addresses
JDK-8269650.

Testing:
Existing tests for GetStringCritical are in various vmTestbase/gc/lock
tests and vmTestbase/nsk/stress/jni/jnistress004.java.

Ran mach5 tier1, tier5.  Tier5 is where the vmTestbase/gc/lock and
vmTestbase/nsk/stress/jni tests are run.

Locally (linux-x64) ran those tests with Shenandoah, with and without
string deduplication enabled.

/issue add JDK-8269650

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8269661](https://bugs.openjdk.java.net/browse/JDK-8269661): JNI_GetStringCritical does not lock char array
 * [JDK-8269650](https://bugs.openjdk.java.net/browse/JDK-8269650): Optimize gc-locker in [Get|Release]StringCritical for latin string


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to ea8bd3861bfbf44626b3bfc72c60413baeda2873
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to ea8bd3861bfbf44626b3bfc72c60413baeda2873


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/209.diff">https://git.openjdk.java.net/jdk17/pull/209.diff</a>

</details>
