### PR TITLE
8269772: [macos-aarch64] test compilation failed with "SocketException: No buffer space available"

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -28,7 +28,7 @@ java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/tools/jcmd \
 sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
 com/sun/tools/attach sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
-java/util/BitSet/stream javax/rmi
+java/util/BitSet/stream javax/rmi java/net/httpclient/websocket
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
Please find here a trivial fix for:

8269772: [macos-aarch64] test compilation failed with "SocketException: No buffer space available"

Running several of the websocket tests concurrently on some of the CI machines is causing resource exhaustion, because resources are only freed after the TIMED_WAIT delay has expired once the tests have finished.
The proposed solution is to run these tests in exclusive dir mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269772](https://bugs.openjdk.java.net/browse/JDK-8269772): [macos-aarch64] test compilation failed with "SocketException: No buffer space available"


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/210.diff">https://git.openjdk.java.net/jdk17/pull/210.diff</a>

</details>
