### PR TITLE
8269873: serviceability/sa/Clhsdb tests are using a C2 specific VMStruct field

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,6 @@ public class ClhsdbField {
                 "field InstanceKlass _constants ConstantPool*",
                 "field Klass _name Symbol*",
                 "field JavaThread _osthread OSThread*",
-                "field JVMState _bci",
                 "field TenuredGeneration _the_space ContiguousSpace*",
                 "field VirtualSpace _low_boundary char*",
                 "field MethodCounters _backedge_counter InvocationCounter",

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,6 @@ public class ClhsdbVmStructsDump {
                 "type DictionaryEntry KlassHashtableEntry",
                 "field JavaThread _osthread OSThread*",
                 "type TenuredGeneration CardGeneration",
-                "field JVMState _bci",
                 "type Universe null",
                 "type ConstantPoolCache MetaspaceObj"));
             test.run(theApp.getPid(), cmds, expStrMap, null);


### PR DESCRIPTION
Hi,

please review this small change for two Clhsdb test cases, which are using C2 specific fields during testing. This makes the tests fail, if C2 is not available during testing.