### PR TITLE
8269575: C2: assert(false) failed: graph should be schedulable after JDK-8252372

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5033,19 +5033,19 @@ Node* PhaseIdealLoop::get_late_ctrl_with_anti_dep(LoadNode* n, Node* early, Node
           }
         }
       }
-      // For Phis only consider Region's inputs that were reached by following the memory edges
-      if (LCA != early) {
-        for (uint i = 0; i < worklist.size(); i++) {
-          Node* s = worklist.at(i);
-          if (s->is_Phi() && C->can_alias(s->adr_type(), load_alias_idx)) {
-            Node* r = s->in(0);
-            for (uint j = 1; j < s->req(); j++) {
-              Node* in = s->in(j);
-              Node* r_in = r->in(j);
-              // We can't reach any node from a Phi because we don't enqueue Phi's uses above
-              if (((worklist.member(in) && !in->is_Phi()) || in == mem) && is_dominator(early, r_in)) {
-                LCA = dom_lca_for_get_late_ctrl(LCA, r_in, n);
-              }
+    }
+    // For Phis only consider Region's inputs that were reached by following the memory edges
+    if (LCA != early) {
+      for (uint i = 0; i < worklist.size(); i++) {
+        Node* s = worklist.at(i);
+        if (s->is_Phi() && C->can_alias(s->adr_type(), load_alias_idx)) {
+          Node* r = s->in(0);
+          for (uint j = 1; j < s->req(); j++) {
+            Node* in = s->in(j);
+            Node* r_in = r->in(j);
+            // We can't reach any node from a Phi because we don't enqueue Phi's uses above
+            if (((worklist.member(in) && !in->is_Phi()) || in == mem) && is_dominator(early, r_in)) {
+              LCA = dom_lca_for_get_late_ctrl(LCA, r_in, n);
             }
           }
         }

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeDueToBrokenAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeDueToBrokenAntiDependency.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8269575
+ * @summary C2: assert(false) failed: graph should be schedulable after JDK-8252372
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestSunkNodeDueToBrokenAntiDependency TestSunkNodeDueToBrokenAntiDependency
+ *
+ */
+
+public class TestSunkNodeDueToBrokenAntiDependency {
+
+    public static final int N = 400;
+
+    public static volatile long instanceCount=-154L;
+    public volatile int iArrFld[]=new int[N];
+
+    public void mainTestSunkNodeDueToBrokenAntiDependency(String[] strArr1) {
+
+        int i8=8, i9=-3, i10=-199, i11=13, i12=8, i13=2;
+        long lArr1[]=new long[N];
+
+        for (int i7 : iArrFld) {
+            for (i8 = 1; i8 < 63; ++i8) {
+                i10 = 1;
+                while (++i10 < 2) {
+                    i7 += (int)TestSunkNodeDueToBrokenAntiDependency.instanceCount;
+                    lArr1[i10 + 1] -= 3;
+                }
+                i11 = 2;
+                do {
+                    byte by2=-104;
+                    by2 = (byte)TestSunkNodeDueToBrokenAntiDependency.instanceCount;
+                } while (--i11 > 0);
+                i9 <<= 6;
+                for (i12 = i8; 2 > i12; i12++) {
+                    switch (((i11 >>> 1) % 1) + 66) {
+                    case 66:
+                        TestSunkNodeDueToBrokenAntiDependency.instanceCount -= i13;
+                        break;
+                    }
+
+                }
+            }
+        }
+    }
+    public static void main(String[] strArr) {
+        TestSunkNodeDueToBrokenAntiDependency _instance = new TestSunkNodeDueToBrokenAntiDependency();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.mainTestSunkNodeDueToBrokenAntiDependency(strArr);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeDueToBrokenAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeDueToBrokenAntiDependency.java
@@ -37,7 +37,7 @@ public class TestSunkNodeDueToBrokenAntiDependency {
     public static volatile long instanceCount=-154L;
     public volatile int iArrFld[]=new int[N];
 
-    public void mainTestSunkNodeDueToBrokenAntiDependency(String[] strArr1) {
+    public void mainTest() {
 
         int i8=8, i9=-3, i10=-199, i11=13, i12=8, i13=2;
         long lArr1[]=new long[N];
@@ -46,19 +46,19 @@ public class TestSunkNodeDueToBrokenAntiDependency {
             for (i8 = 1; i8 < 63; ++i8) {
                 i10 = 1;
                 while (++i10 < 2) {
-                    i7 += (int)TestSunkNodeDueToBrokenAntiDependency.instanceCount;
+                    i7 += (int)instanceCount;
                     lArr1[i10 + 1] -= 3;
                 }
                 i11 = 2;
                 do {
                     byte by2=-104;
-                    by2 = (byte)TestSunkNodeDueToBrokenAntiDependency.instanceCount;
+                    by2 = (byte)instanceCount;
                 } while (--i11 > 0);
                 i9 <<= 6;
                 for (i12 = i8; 2 > i12; i12++) {
                     switch (((i11 >>> 1) % 1) + 66) {
                     case 66:
-                        TestSunkNodeDueToBrokenAntiDependency.instanceCount -= i13;
+                        instanceCount -= i13;
                         break;
                     }
 
@@ -69,7 +69,7 @@ public class TestSunkNodeDueToBrokenAntiDependency {
     public static void main(String[] strArr) {
         TestSunkNodeDueToBrokenAntiDependency _instance = new TestSunkNodeDueToBrokenAntiDependency();
         for (int i = 0; i < 10; i++ ) {
-            _instance.mainTestSunkNodeDueToBrokenAntiDependency(strArr);
+            _instance.mainTest();
         }
     }
 }


### PR DESCRIPTION
8252372 moved processing of Phis by anti-dependence analysis in the:

    for (uint i = 0; i < worklist.size() && LCA != early; i++) {

loop by accident. The intent is to process all Phis last.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269575](https://bugs.openjdk.java.net/browse/JDK-8269575): C2: assert(false) failed: graph should be schedulable after JDK-8252372


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to d942c14389574808d8f659c57ba6ec3f6573de04
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/214.diff">https://git.openjdk.java.net/jdk17/pull/214.diff</a>

</details>
