### PR TITLE
8269635: Stress test SEGV while emitting OldObjectSample

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -91,6 +91,15 @@ void ObjectSampleCheckpoint::on_thread_exit(JavaThread* jt) {
   }
 }
 
+void ObjectSampleCheckpoint::clear() {
+  assert(SafepointSynchronize::is_at_safepoint(), "invariant");
+  if (unloaded_thread_id_set != NULL) {
+    delete unloaded_thread_id_set;
+    unloaded_thread_id_set = NULL;
+  }
+  assert(unloaded_thread_id_set == NULL, "invariant");
+}
+
 template <typename Processor>
 static void do_samples(ObjectSample* sample, const ObjectSample* end, Processor& processor) {
   assert(sample != NULL, "invariant");

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -69,12 +69,11 @@ Semaphore ThreadIdExclusiveAccess::_mutex_semaphore(1);
 
 static bool has_thread_exited(traceid tid) {
   assert(tid != 0, "invariant");
-  return unloaded_thread_id_set != NULL && JfrPredicate<traceid, compare_traceid>::test(unloaded_thread_id_set, tid);
-}
-
-static bool add(GrowableArray<traceid>* set, traceid id) {
-  assert(set != NULL, "invariant");
-  return JfrMutablePredicate<traceid, compare_traceid>::test(set, id);
+  if (unloaded_thread_id_set == NULL) {
+    return false;
+  }
+  ThreadIdExclusiveAccess lock;
+  return JfrPredicate<traceid, compare_traceid>::test(unloaded_thread_id_set, tid);
 }
 
 static void add_to_unloaded_thread_set(traceid tid) {
@@ -82,7 +81,7 @@ static void add_to_unloaded_thread_set(traceid tid) {
   if (unloaded_thread_id_set == NULL) {
     unloaded_thread_id_set = c_heap_allocate_array<traceid>();
   }
-  add(unloaded_thread_id_set, tid);
+  JfrMutablePredicate<traceid, compare_traceid>::test(unloaded_thread_id_set, tid);
 }
 
 void ObjectSampleCheckpoint::on_thread_exit(JavaThread* jt) {

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -41,9 +41,9 @@ class Thread;
 
 class ObjectSampleCheckpoint : AllStatic {
   friend class EventEmitter;
+  friend class ObjectSampler;
   friend class PathToGcRootsOperation;
   friend class StackTraceBlobInstaller;
-  friend class StartOperation;
  private:
   static void add_to_leakp_set(const InstanceKlass* ik, traceid method_id);
   static int save_mark_words(const ObjectSampler* sampler, ObjectSampleMarker& marker, bool emit_all);

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -43,11 +43,13 @@ class ObjectSampleCheckpoint : AllStatic {
   friend class EventEmitter;
   friend class PathToGcRootsOperation;
   friend class StackTraceBlobInstaller;
+  friend class StartOperation;
  private:
   static void add_to_leakp_set(const InstanceKlass* ik, traceid method_id);
   static int save_mark_words(const ObjectSampler* sampler, ObjectSampleMarker& marker, bool emit_all);
   static void write_stacktrace(const JfrStackTrace* trace, JfrCheckpointWriter& writer);
   static void write(const ObjectSampler* sampler, EdgeStore* edge_store, bool emit_all, Thread* thread);
+  static void clear();
  public:
   static void on_type_set(JfrCheckpointWriter& writer);
   static void on_type_set_unload(JfrCheckpointWriter& writer);

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -108,8 +108,8 @@ ObjectSampler::~ObjectSampler() {
 bool ObjectSampler::create(size_t size) {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   assert(_oop_storage != NULL, "should be already created");
-  assert(_instance == NULL, "invariant");
   ObjectSampleCheckpoint::clear();
+  assert(_instance == NULL, "invariant");
   _instance = new ObjectSampler(size);
   return _instance != NULL;
 }

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -27,6 +27,7 @@
 #include "gc/shared/oopStorage.hpp"
 #include "gc/shared/oopStorageSet.hpp"
 #include "jfr/jfrEvents.hpp"
+#include "jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp"
 #include "jfr/leakprofiler/sampling/objectSample.hpp"
 #include "jfr/leakprofiler/sampling/objectSampler.hpp"
 #include "jfr/leakprofiler/sampling/sampleList.hpp"
@@ -108,6 +109,7 @@ bool ObjectSampler::create(size_t size) {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   assert(_oop_storage != NULL, "should be already created");
   assert(_instance == NULL, "invariant");
+  ObjectSampleCheckpoint::clear();
   _instance = new ObjectSampler(size);
   return _instance != NULL;
 }


### PR DESCRIPTION
Greetings,

please help review this change set to protect the unloaded thread id set from growing, and hence de-allocated, in the middle of inspection.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269635](https://bugs.openjdk.java.net/browse/JDK-8269635): Stress test SEGV while emitting OldObjectSample


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/218.diff">https://git.openjdk.java.net/jdk17/pull/218.diff</a>

</details>
