### PR TITLE
8269955: ProblemList compiler/vectorapi/VectorCastShape[64|128]Test.java tests on x86

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,6 +70,8 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
+compiler/vectorapi/VectorCastShape128Test.java 8269952 generic-x64
+compiler/vectorapi/VectorCastShape64Test.java 8269952 generic-x64
 
 #############################################################################
 


### PR DESCRIPTION
In order to reduce the noise in the CIs put on ProblemList next tests for x86 until [8269952](https://bugs.openjdk.java.net/browse/JDK-8269952) is fixed: 

compiler/vectorapi/VectorCastShape128Test.java 
compiler/vectorapi/VectorCastShape64Test.java 

Tested tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269955](https://bugs.openjdk.java.net/browse/JDK-8269955): ProblemList compiler/vectorapi/VectorCastShape[64|128]Test.java tests on x86


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/221.diff">https://git.openjdk.java.net/jdk17/pull/221.diff</a>

</details>
