### PR TITLE
8270006: Switches with 'case null:' should be exhaustive

### DIFF
--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -185,4 +185,9 @@ public class SwitchErrors {
             default -> null;
         };
     }
+    void exhaustiveAndNull(String s) {
+        switch (s) {
+            case null: break;
+        }
+    }
 }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -42,6 +42,7 @@ SwitchErrors.java:91:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:97:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:104:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:164:9: compiler.err.not.exhaustive.statement
+SwitchErrors.java:189:9: compiler.err.not.exhaustive.statement
 - compiler.note.preview.filename: SwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-44 errors
+45 errors


### PR DESCRIPTION
Code like:
```
    void exhaustiveAndNull(String s) {
        switch (s) {
            case null: break;
        }
    }
```

should be rejected, because the switch is no exhaustive, but it is a "new" switch. (Note that this not a problem for switch expressions, which always have to be exhaustive.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270006](https://bugs.openjdk.java.net/browse/JDK-8270006): Switches with 'case null:' should be exhaustive


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/224.diff">https://git.openjdk.java.net/jdk17/pull/224.diff</a>

</details>
