### PR TITLE
8259848: Interim javadoc build does not support platform links

### DIFF
--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -61,11 +61,12 @@ $(eval $(call SetupJavaCompilation, COMPILE_CREATE_SYMBOLS, \
         $(COMPILECREATESYMBOLS_ADD_EXPORTS), \
 ))
 
+GENERATE_SYMBOLS_FROM_JDK_VERSION := 11
 JDK_JAVADOC_DIR := $(JDK_OUTPUTDIR)/modules/jdk.javadoc
 ELEMENT_LISTS_PKG := jdk/javadoc/internal/doclets/toolkit/resources/releases
 ELEMENT_LISTS_DIR := $(JDK_JAVADOC_DIR)/$(ELEMENT_LISTS_PKG)
 
-$(JDK_JAVADOC_DIR)/_element_lists: \
+$(JDK_JAVADOC_DIR)/_element_lists.marker: \
     $(COMPILE_CREATE_SYMBOLS) \
     $(wildcard $(TOPDIR)/make/data/symbols/*) \
     $(MODULE_INFOS)
@@ -81,7 +82,7 @@ $(JDK_JAVADOC_DIR)/_element_lists: \
 	        build-javadoc-data \
 	        $(CT_DATA_DESCRIPTION) \
 	        $(ELEMENT_LISTS_DIR) \
-	        11 \
+	        $(GENERATE_SYMBOLS_FROM_JDK_VERSION) \
 	)
         # Generate element-list file for the current JDK version
 	$(call ExecuteWithLog, $@_current, \
@@ -101,13 +102,13 @@ $(JDK_JAVADOC_DIR)/_element_lists: \
 INTERIM_JDK_JAVADOC_DIR := $(BUILDTOOLS_OUTPUTDIR)/interim_langtools_modules/jdk.javadoc.interim
 INTERIM_ELEMENT_LISTS_DIR := $(INTERIM_JDK_JAVADOC_DIR)/$(ELEMENT_LISTS_PKG)
 
-$(INTERIM_JDK_JAVADOC_DIR)/_element_lists: $(JDK_JAVADOC_DIR)/_element_lists
-	$(RM) -r $(INTERIM_ELEMENT_LISTS_DIR)
-	$(MKDIR) -p $(INTERIM_ELEMENT_LISTS_DIR)
+$(INTERIM_JDK_JAVADOC_DIR)/_element_lists.marker: $(JDK_JAVADOC_DIR)/_element_lists.marker
+	$(call MakeDir, $(INTERIM_ELEMENT_LISTS_DIR))
+	$(RM) -r $(INTERIM_ELEMENT_LISTS_DIR)/*
 	$(CP) -R $(ELEMENT_LISTS_DIR)/* $(INTERIM_ELEMENT_LISTS_DIR)/
 	$(TOUCH) $@
 
 ################################################################################
 
-TARGETS += $(JDK_JAVADOC_DIR)/_element_lists \
-    $(INTERIM_JDK_JAVADOC_DIR)/_element_lists
+TARGETS += $(JDK_JAVADOC_DIR)/_element_lists.marker \
+    $(INTERIM_JDK_JAVADOC_DIR)/_element_lists.marker

--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -61,36 +61,53 @@ $(eval $(call SetupJavaCompilation, COMPILE_CREATE_SYMBOLS, \
         $(COMPILECREATESYMBOLS_ADD_EXPORTS), \
 ))
 
-$(SUPPORT_OUTPUTDIR)/javadoc-symbols/symbols: \
+JDK_JAVADOC_DIR := $(JDK_OUTPUTDIR)/modules/jdk.javadoc
+ELEMENT_LISTS_PKG := jdk/javadoc/internal/doclets/toolkit/resources/releases
+ELEMENT_LISTS_DIR := $(JDK_JAVADOC_DIR)/$(ELEMENT_LISTS_PKG)
+
+$(JDK_JAVADOC_DIR)/_element_lists: \
     $(COMPILE_CREATE_SYMBOLS) \
     $(wildcard $(TOPDIR)/make/data/symbols/*) \
     $(MODULE_INFOS)
-	$(RM) -r $(@D)
-	$(MKDIR) -p $(@D)
-	$(ECHO) Creating javadoc element list
-	$(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
-	    $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
-	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
-	    build.tools.symbolgenerator.CreateSymbols \
-	    build-javadoc-data \
-	    $(CT_DATA_DESCRIPTION) \
-	    $(JDK_OUTPUTDIR)/modules/jdk.javadoc/jdk/javadoc/internal/doclets/toolkit/resources/releases \
-	    11
-	$(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
-	    $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
-	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
-	    build.tools.symbolgenerator.JavadocElementList \
-	    $(JDK_OUTPUTDIR)/modules/jdk.javadoc/jdk/javadoc/internal/doclets/toolkit/resources/releases/element-list-$(JDK_SOURCE_TARGET_VERSION).txt \
-	    $(JAVADOC_MODULESOURCEPATH) \
-	    $(JAVADOC_MODULES)
+	$(call MakeTargetDir)
+	$(call LogInfo, Creating javadoc element lists)
+	$(RM) -r $(ELEMENT_LISTS_DIR)
+        # Generate element-list files for JDK 11 to current-1
+	$(call ExecuteWithLog, $@_historic, \
+	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
+	        $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
+	        -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
+	        build.tools.symbolgenerator.CreateSymbols \
+	        build-javadoc-data \
+	        $(CT_DATA_DESCRIPTION) \
+	        $(ELEMENT_LISTS_DIR) \
+	        11 \
+	)
+        # Generate element-list file for the current JDK version
+	$(call ExecuteWithLog, $@_current, \
+	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
+	        $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
+	        -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
+	        build.tools.symbolgenerator.JavadocElementList \
+	        $(ELEMENT_LISTS_DIR)/element-list-$(JDK_SOURCE_TARGET_VERSION).txt \
+	        $(JAVADOC_MODULESOURCEPATH) \
+	        $(JAVADOC_MODULES) \
+	)
 	$(TOUCH) $@
 
-# Copy ct.sym to the modules libs dir
-$(eval $(call SetupCopyFiles, COPY_TO_LIBS, \
-    FILES := $(SUPPORT_OUTPUTDIR)/javadoc-symbols/*.txt, \
-    DEST := $(JDK_OUTPUTDIR)/modules/jdk.javadoc/jdk/javadoc/internal/doclets/toolkit/resources/releases, \
-))
+################################################################################
+# Copy element-lists to interim langtools
 
-TARGETS += $(SUPPORT_OUTPUTDIR)/javadoc-symbols/symbols
+INTERIM_JDK_JAVADOC_DIR := $(BUILDTOOLS_OUTPUTDIR)/interim_langtools_modules/jdk.javadoc.interim
+INTERIM_ELEMENT_LISTS_DIR := $(INTERIM_JDK_JAVADOC_DIR)/$(ELEMENT_LISTS_PKG)
+
+$(INTERIM_JDK_JAVADOC_DIR)/_element_lists: $(JDK_JAVADOC_DIR)/_element_lists
+	$(RM) -r $(INTERIM_ELEMENT_LISTS_DIR)
+	$(MKDIR) -p $(INTERIM_ELEMENT_LISTS_DIR)
+	$(CP) -R $(ELEMENT_LISTS_DIR)/* $(INTERIM_ELEMENT_LISTS_DIR)/
+	$(TOUCH) $@
 
 ################################################################################
+
+TARGETS += $(JDK_JAVADOC_DIR)/_element_lists \
+    $(INTERIM_JDK_JAVADOC_DIR)/_element_lists


### PR DESCRIPTION
This patch adds copying of element-list files generated for jdk.javadoc to the interim langtools version of jdk.javadoc. I'm also refactoring the jdk.javadoc/Gendata.gmk file a bit to better adhere to current build infra standards as this was missed in the original review of this file. Rebuilding should now work better with the various clean targets and any problems with the generation tool will be captured in separate log files, along with the command lines.

@hns Can you verify that this solves the problem you reported?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259848](https://bugs.openjdk.java.net/browse/JDK-8259848): Interim javadoc build does not support platform links


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to 6c09fef2715aafd4e7f791b634bed95d89147177
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 6c09fef2715aafd4e7f791b634bed95d89147177
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/227.diff">https://git.openjdk.java.net/jdk17/pull/227.diff</a>

</details>
