### PR TITLE
8269929: (test) Add diagnostic info to ProceessBuilder/Basic.java for unexpected output

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -899,6 +899,7 @@ public class Basic {
         } catch (Throwable t) { unexpected(t); return ""; }
     }
 
+    @SuppressWarnings("removal")
     static void testIORedirection() throws Throwable {
         final File ifile = new File("ifile");
         final File ofile = new File("ofile");
@@ -1303,6 +1304,7 @@ public class Basic {
 
     }
 
+    @SuppressWarnings("removal")
     private static void realMain(String[] args) throws Throwable {
         if (Windows.is())
             System.out.println("This appears to be a Windows system.");
@@ -2184,7 +2186,9 @@ public class Basic {
                             }
                             if (r >= 0) {
                                 // The child sent unexpected output; print it to diagnose
-                                System.out.println("Unexpected child output:");
+                                System.out.println("Unexpected child output, to: " +
+                                        ((action & 0x1) == 0 ? "getInputStream" : "getErrorStream"));
+                                System.out.println("Child args: " + childArgs);
                                 if ((action & 0x2) == 0) {
                                     System.out.write(r);    // Single character
 
@@ -2205,7 +2209,7 @@ public class Basic {
 
                 thread.start();
                 latch.await();
-                Thread.sleep(10);
+                Thread.sleep(30);
 
                 if (s instanceof BufferedInputStream) {
                     // Wait until after the s.read occurs in "thread" by
@@ -2662,6 +2666,7 @@ public class Basic {
     //----------------------------------------------------------------
     // A Policy class designed to make permissions fiddling very easy.
     //----------------------------------------------------------------
+    @SuppressWarnings("removal")
     private static class Policy extends java.security.Policy {
         static final java.security.Policy DEFAULT_POLICY = java.security.Policy.getPolicy();
 


### PR DESCRIPTION
The test java/lang/ProcessBuilder/Basic.java continues to fail intermittently with unexpected output from the VM.
It appears that destroying the process causes a vm thread to fail to be started.
Extend the delay between starting the child and destroying it.
Add diagnostics to be specific about which case failed.
Incidentally, suppress compiler warnings about SecurityManager use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269929](https://bugs.openjdk.java.net/browse/JDK-8269929): (test) Add diagnostic info to ProceessBuilder/Basic.java for unexpected output


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/228.diff">https://git.openjdk.java.net/jdk17/pull/228.diff</a>

</details>
