### PR TITLE
8269738: AssertionError when combining pattern matching and function closure

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -819,7 +819,7 @@ public class TransPatterns extends TreeTranslator {
         VarSymbol bindingDeclared(BindingSymbol varSymbol) {
             VarSymbol res = parent.bindingDeclared(varSymbol);
             if (res == null) {
-                res = new VarSymbol(varSymbol.flags(), varSymbol.name, varSymbol.type, varSymbol.owner);
+                res = new VarSymbol(varSymbol.flags(), varSymbol.name, varSymbol.type, currentMethodSym);
                 res.setTypeAttributes(varSymbol.getRawTypeAttributes());
                 hoistedVarMap.put(varSymbol, res);
             }

--- a/test/langtools/tools/javac/patterns/LambdaCannotCapturePatternVariables.java
+++ b/test/langtools/tools/javac/patterns/LambdaCannotCapturePatternVariables.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8267610
+ * @bug 8267610 8269738
  * @summary LambdaToMethod cannot capture pattern variables. So the TransPatterns should
  *          transform the pattern variables and symbols to normal variables and symbols.
  * @compile --enable-preview -source ${jdk.version} LambdaCannotCapturePatternVariables.java
@@ -34,11 +34,24 @@ import java.util.function.Supplier;
 
 public class LambdaCannotCapturePatternVariables {
 
+    static Number num1 = 1;
+    static Number num2 = null;
+    static Number staticNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    static Number staticNum2 = (num2 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    Number instanceNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    Number instanceNum2 = (num2 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+
     public static void main(String[] args) {
         var testVar = new LambdaCannotCapturePatternVariables();
         testVar.testInstanceOfPatternVariable(Integer.valueOf(1));
         testVar.testSwitchPatternVariable(Integer.valueOf(1));
         testVar.test(Integer.valueOf(1));
+        assertTrue(staticNum1 != null, "staticNum1 is null unexpectedly");
+        assertTrue(staticNum2 == null, "staticNum1 is not null unexpectedly");
+        assertTrue(testVar.instanceNum1 != null, "instanceNum1 is null unexpectedly");
+        assertTrue(testVar.instanceNum2 == null, "instanceNum2 is not null unexpectedly");
+        assertTrue(staticNum1.intValue() == 1, "staticNum1.intValue() is not equal to 1");
+        assertTrue(testVar.instanceNum1.intValue() == 1, "instanceNum1.intValue() is not equal to 1");
     }
 
     public Integer testInstanceOfPatternVariable(Object x) {
@@ -68,5 +81,10 @@ public class LambdaCannotCapturePatternVariables {
                 ((Supplier<Integer>) (() -> {
                     return ((y instanceof Integer z) ? z : bar);
                 })).get() : bar);
+    }
+
+    static void assertTrue(boolean cond, String info) {
+        if (!cond)
+            throw new AssertionError(info);
     }
 }


### PR DESCRIPTION
This is a duplicated PR of the [jdk/pull/4678](https://github.com/openjdk/jdk/pull/4678).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269738](https://bugs.openjdk.java.net/browse/JDK-8269738): AssertionError when combining pattern matching and function closure


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/230/head:pull/230` \
`$ git checkout pull/230`

Update a local copy of the PR: \
`$ git checkout pull/230` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 230`

View PR using the GUI difftool: \
`$ git pr show -t 230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/230.diff">https://git.openjdk.java.net/jdk17/pull/230.diff</a>

</details>
