### PR TITLE
8261147: C2: Node is wrongly marked as reduction resulting in a wrong execution due to wrong vector instructions

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2203,10 +2203,14 @@ void PhaseIdealLoop::clone_loop( IdealLoopTree *loop, Node_List &old_new, int dd
 
   // Step 1: Clone the loop body.  Make the old->new mapping.
   uint i;
-  for( i = 0; i < loop->_body.size(); i++ ) {
-    Node *old = loop->_body.at(i);
-    Node *nnn = old->clone();
-    old_new.map( old->_idx, nnn );
+  for (i = 0; i < loop->_body.size(); i++) {
+    Node* old = loop->_body.at(i);
+    Node* nnn = old->clone();
+    old_new.map(old->_idx, nnn);
+    if (old->is_reduction()) {
+      // Reduction flag is not copied by default. Copy it here when cloning the entire loop body.
+      nnn->add_flag(Node::Flag_is_reduction);
+    }
     if (C->do_vector_loop()) {
       cm.verify_insert_and_clone(old, nnn, cm.clone_idx());
     }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -528,6 +528,10 @@ Node *Node::clone() const {
     // If it is applicable, it will happen anyway when the cloned node is registered with IGVN.
     n->remove_flag(Node::NodeFlags::Flag_for_post_loop_opts_igvn);
   }
+  if (n->is_reduction()) {
+    // Do not copy reduction information. This must be explicitly set by the calling code.
+    n->remove_flag(Node::Flag_is_reduction);
+  }
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->register_potential_barrier_node(n);
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestWronglyMarkedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestWronglyMarkedReduction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8261147
+ * @summary Cloned node in AddNode::Ideal is no longer a reduction but is still marked as such leading to wrong vectorization.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestWronglyMarkedReduction::*
+ *                   compiler.loopopts.superword.TestWronglyMarkedReduction
+ */
+package compiler.loopopts.superword;
+
+public class TestWronglyMarkedReduction {
+    public static long b = 0;
+
+    public static void main(String[] p) {
+        TestWronglyMarkedReduction u = new TestWronglyMarkedReduction();
+        for (int i = 0; i < 1000; i++) {
+            b = 0;
+            test();
+        }
+    }
+
+    public static void test() {
+        long r[] = new long[20];
+        for (int q = 0; q < 12; ++q) {
+            for (int i = 1; i < 6; ++i) {
+                r[i + 1] += b;
+            }
+            b += 2;
+        }
+        check(r);
+    }
+
+    public static void check(long[] a) {
+        for (int j = 0; j < 20; j++) {
+            if (j >= 2 && j <= 6) {
+                if (a[j] != 132) {
+                    throw new RuntimeException("expected 132 at index " + j + " but got " + a[j]);
+                }
+            } else if (a[j] != 0) {
+                throw new RuntimeException("expected 0 at index " + j + " but got " + a[j]);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
C2 produces a wrong result for the testcase due to treating a non-reduction `AddL` node wrongly as a reduction (`Node::is_reduction()` is true). This node is later part of a pack in the superword algorithm which wrongly treats it as a reduction. As a result, we create an `AddReductionVL` instead of an `AddVL` node, letting the test fail.

The wrong reduction can be traced back to `AddNode::Ideal` where we create a clone of an `AddL` node which is marked as a reduction. However, the clone itself is no longer a reduction but is still marked as such. `Node::clone()` simply copies the `Flag_is_reduction` flag in `Node::_flags`:
https://github.com/openjdk/jdk17/blob/4f707591754e5e7f747d1d0a47f78f49060771c2/src/hotspot/share/opto/addnode.cpp#L181-L196

I don't think we need to clone the `Flag_is_reduction` flag by default in `Node::clone()`. I went through the uses of `Node::clone()` and I think we only need to clone the flag when copying an entire loop body in `PhaseIdealLoop::clone_loop()`.  That's what I propose as a fix. This approach also avoids the need to think about reductions in future uses of `Node::clone()` with a special handling for it as it would be required in `AddNode::Ideal` etc.

I did some performance testing with some common benchmarks which looked good. I also ran the follwing JTreg tests which showed the same number of newly created vectors with and without the fix:
```
jtreg -testjdk:jdk-18/fastdebug -va -javaoptions:'-server -Xbatch -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+TraceNewVectors' -J-Djavatest.maxOutputSize=1000000 compiler/c2/cr6340864/ compiler/codegen/ compiler/loopopts/superword/ compiler/vectorization > new_vects.log
grep "new Vector node:" new_vects.log | wc
  20190  521206 4398994
```

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261147](https://bugs.openjdk.java.net/browse/JDK-8261147): C2: Node is wrongly marked as reduction resulting in a wrong execution due to wrong vector instructions


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/231/head:pull/231` \
`$ git checkout pull/231`

Update a local copy of the PR: \
`$ git checkout pull/231` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 231`

View PR using the GUI difftool: \
`$ git pr show -t 231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/231.diff">https://git.openjdk.java.net/jdk17/pull/231.diff</a>

</details>
