### PR TITLE
8266345: (fs) Custom DefaultFileSystemProvider security related loops

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/PolicyFile.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyFile.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import jdk.internal.access.JavaSecurityAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.util.StaticProperty;
+import sun.nio.fs.DefaultFileSystemProvider;
 import sun.security.util.*;
 import sun.net.www.ParseUtil;
 
@@ -277,6 +278,13 @@ public class PolicyFile extends java.security.Policy {
         Collections.newSetFromMap(new ConcurrentHashMap<URL,Boolean>());
 
     /**
+     * Use the platform's default file system to avoid recursive initialization
+     * issues when the VM is configured to use a custom file system provider.
+     */
+    private static final java.nio.file.FileSystem builtInFS =
+        DefaultFileSystemProvider.theFileSystem();
+
+    /**
      * Initializes the Policy object and reads the default policy
      * configuration file(s) into the Policy object.
      */
@@ -475,7 +483,7 @@ public class PolicyFile extends java.security.Policy {
     }
 
     private void initDefaultPolicy(PolicyInfo newInfo) {
-        Path defaultPolicy = Path.of(StaticProperty.javaHome(),
+        Path defaultPolicy = builtInFS.getPath(StaticProperty.javaHome(),
                                      "lib",
                                      "security",
                                      "default.policy");

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8266345
  * @modules jdk.jartool
  * @library /test/lib
  * @build SetDefaultProvider TestProvider m/* jdk.test.lib.process.ProcessTools
@@ -69,6 +70,22 @@ public class SetDefaultProvider {
         String testClasses = System.getProperty("test.classes");
         String classpath = moduleClasses + File.pathSeparator + testClasses;
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
+        assertTrue(exitValue == 0);
+    }
+
+    /**
+     * Test override of default FileSystemProvider with the main application
+     * on the class path and a SecurityManager enabled.
+     */
+    public void testClassPathWithSecurityManager() throws Exception {
+        String moduleClasses = moduleClasses();
+        String testClasses = System.getProperty("test.classes");
+        String classpath = moduleClasses + File.pathSeparator + testClasses;
+        String policyFile = System.getProperty("test.src", ".")
+            + File.separator + "fs.policy";
+        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath,
+            "-Dtest.classes=" + testClasses, "-Djava.security.manager",
+            "-Djava.security.policy==" + policyFile, "p.Main");
         assertTrue(exitValue == 0);
     }
 

--- a/test/jdk/java/nio/file/spi/fs.policy
+++ b/test/jdk/java/nio/file/spi/fs.policy
@@ -1,0 +1,3 @@
+grant codeBase "file:${test.classes}${/}-" {
+    permission java.io.FilePermission "${java.io.tmpdir}${/}-", "write";
+};


### PR DESCRIPTION
Please review this fix to use the platform's default file system to avoid recursive policy initialization
issues when a SecurityManager is enabled and the VM is configured to use a custom file system provider.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266345](https://bugs.openjdk.java.net/browse/JDK-8266345): (fs) Custom DefaultFileSystemProvider security related loops


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Contributors
 * Brian Burkhalter `<bpb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/232.diff">https://git.openjdk.java.net/jdk17/pull/232.diff</a>

</details>
