### PR TITLE
8269558: fix of JDK-8252657 missed to update history at the end of JVM TI spec

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -15036,6 +15036,11 @@ typedef void (JNICALL *jvmtiEventVMInit)
         - Specify that RedefineClasses and RetransformClasses are not allowed
           to change the class file PermittedSubclasses attribute.
   </change>
+  <change date="15 January 2021" version="17.0.0">
+      Minor clarification in the section "Agent Shutdown" that says the
+      implementation may choose to not call the Agent_OnUnload function
+      if the Agent_OnAttach/Agent_OnAttach_L function reported an error. 
+  </change>
   <change date="8 June 2021" version="17.0.0">
       Minor update to deprecate Heap functions 1.0.
   </change>


### PR DESCRIPTION
The fix of:
   8252657 JVMTI agent is not unloaded when Agent_OnAttach is failed
did not update the JVM TI spec history at the end of document. 
This PR adds missed item to the JVM TI spec history.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269558](https://bugs.openjdk.java.net/browse/JDK-8269558): fix of JDK-8252657 missed to update history at the end of JVM TI spec


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 7a5b9b3bc0b71765c57b682cea8df27a1c16c5d5
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 7a5b9b3bc0b71765c57b682cea8df27a1c16c5d5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/233.diff">https://git.openjdk.java.net/jdk17/pull/233.diff</a>

</details>
