### PR TITLE
8269795: C2: Out of bounds array load floats above its range check in loop peeling resulting in SEGV

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -507,24 +507,24 @@ uint IdealLoopTree::estimate_peeling(PhaseIdealLoop *phase) {
 // If we got the effect of peeling, either by actually peeling or by making
 // a pre-loop which must execute at least once, we can remove all
 // loop-invariant dominated tests in the main body.
-void PhaseIdealLoop::peeled_dom_test_elim(IdealLoopTree *loop, Node_List &old_new) {
+void PhaseIdealLoop::peeled_dom_test_elim(IdealLoopTree* loop, Node_List& old_new) {
   bool progress = true;
   while (progress) {
-    progress = false;           // Reset for next iteration
-    Node *prev = loop->_head->in(LoopNode::LoopBackControl);//loop->tail();
-    Node *test = prev->in(0);
+    progress = false; // Reset for next iteration
+    Node* prev = loop->_head->in(LoopNode::LoopBackControl); // loop->tail();
+    Node* test = prev->in(0);
     while (test != loop->_head) { // Scan till run off top of loop
-
       int p_op = prev->Opcode();
       if ((p_op == Op_IfFalse || p_op == Op_IfTrue) &&
-          test->is_If() &&      // Test?
+          test->is_If() && // Test?
           !test->in(1)->is_Con() && // And not already obvious?
           // Condition is not a member of this loop?
           !loop->is_member(get_loop(get_ctrl(test->in(1))))){
         // Walk loop body looking for instances of this test
+        Node* test_cond = test->in(1);
         for (uint i = 0; i < loop->_body.size(); i++) {
-          Node *n = loop->_body.at(i);
-          if (n->is_If() && n->in(1) == test->in(1) /*&& n != loop->tail()->in(0)*/) {
+          Node* n = loop->_body.at(i);
+          if (n->is_If() && n->in(1) == test_cond) {
             // IfNode was dominated by version in peeled loop body
             progress = true;
             dominated_by(old_new[prev->_idx], n);
@@ -534,7 +534,6 @@ void PhaseIdealLoop::peeled_dom_test_elim(IdealLoopTree *loop, Node_List &old_ne
       prev = test;
       test = idom(test);
     } // End of scan tests in loop
-
   } // End of while (progress)
 }
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -515,15 +515,20 @@ void PhaseIdealLoop::peeled_dom_test_elim(IdealLoopTree* loop, Node_List& old_ne
     Node* test = prev->in(0);
     while (test != loop->_head) { // Scan till run off top of loop
       int p_op = prev->Opcode();
-      if ((p_op == Op_IfFalse || p_op == Op_IfTrue) &&
-          test->is_If() && // Test?
-          !test->in(1)->is_Con() && // And not already obvious?
-          // Condition is not a member of this loop?
-          !loop->is_member(get_loop(get_ctrl(test->in(1))))){
+      assert(test != NULL, "test cannot be NULL");
+      Node* test_cond = NULL;
+      if ((p_op == Op_IfFalse || p_op == Op_IfTrue) && test->is_If()) {
+        test_cond = test->in(1);
+      }
+      if (test_cond != NULL && // Test?
+          !test_cond->is_Con() && // And not already obvious?
+          // And condition is not a member of this loop?
+          !loop->is_member(get_loop(get_ctrl(test_cond)))) {
         // Walk loop body looking for instances of this test
-        Node* test_cond = test->in(1);
         for (uint i = 0; i < loop->_body.size(); i++) {
           Node* n = loop->_body.at(i);
+          // Check against cached test condition because dominated_by()
+          // replaces the test condition with a constant.
           if (n->is_If() && n->in(1) == test_cond) {
             // IfNode was dominated by version in peeled loop body
             progress = true;

--- a/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @requires vm.compiler2.enabled
+ * @bug 8269795
+ * @summary PhaseIdealLoop::peeled_dom_test_elim wrongly moves a non-dominated test out of a loop together with control dependent data nodes.
+ *          This results in a crash due to an out of bounds read of an array.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:-TieredCompilation -XX:+StressGCM
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestPeelingRemoveDominatedTest compiler.loopopts.TestPeelingRemoveDominatedTest
+ */
+
+package compiler.loopopts;
+
+public class TestPeelingRemoveDominatedTest {
+    public static int N = 400;
+    static boolean bFld = true;
+    static int iArrFld[] = new int[N];
+
+    public static void main(String[] strArr) {
+        TestPeelingRemoveDominatedTest _instance = new TestPeelingRemoveDominatedTest();
+        for (int i = 0; i < 10; i++) {
+            _instance.mainTest();
+        }
+    }
+
+    public void mainTest() {
+        vMeth();
+    }
+
+
+    static void vMeth() {
+        iArrFld[1] = 2;
+        int i6 = 2;
+        while (--i6 > 0) {
+            try {
+                int i3 = (iArrFld[i6 - 1] / 56);
+                iArrFld[1] = (-139 % i3);
+            } catch (ArithmeticException a_e) {
+            }
+            if (bFld) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the testcase, an out of bounds array load (`LoadI`) floats above its range check resulting in a segfault. The problem can be traced back to incorrectly treating an `If` node, on which the `LoadI` is control dependent, as being dominated in `PhaseIdealLoop::peeled_dom_test_elim`. As a result, `PhaseIdealLoop::dominated_by()` moves the `LoadI` out and before the loop while the range check stays inside the loop.

`peeled_dom_test_elim()` walks through the idom chain of the loop body and tries to find loop-invariant tests. Once it finds one, it not only moves this test out of the loop but also looks for other tests with the same condition node which can be removed. The condition of the dominated tests in the loop are replaced with a `ConI` in `dominated_by()`. The data dependencies on the removed dominated tests are rewired to a peeled node before the loop.

However, the current code directly checks `test->in(1)` at L527 which is only the initial `Bool` node of the dominated test before the first invocation of `dominated_by()` in the loop on L525. Afterwards, `test->in(1)` is a `ConI` node. We now continue to look for tests with an identical `ConI` condition to move their data nodes out of this loop. This is wrong and exactly happens in the testcase: The loop body still contains a not yet cleaned up (by IGVN) `If` node (with a `ConI` condition) of an eliminated skeleton predicate on which an out of bounds  `LoadI` node is control dependent. The `LoadI` is then wrongly rewired out of the loop and before its range check.

The fix is to only check against the initial `test->in(1)` `Bool` node which satisfies the conditions checked on the lines before (L518-520).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269795](https://bugs.openjdk.java.net/browse/JDK-8269795): C2: Out of bounds array load floats above its range check in loop peeling resulting in SEGV


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to c29fd2470626506e8801414e028230665d502c85
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/235.diff">https://git.openjdk.java.net/jdk17/pull/235.diff</a>

</details>
