### PR TITLE
8270151: IncompatibleClassChangeError on empty pattern switch statement case

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3598,7 +3598,7 @@ public class Lower extends TreeTranslator {
             JCThrow thr = make.Throw(makeNewClass(syms.incompatibleClassChangeErrorType,
                                                   List.nil()));
             JCCase c = make.Case(JCCase.STATEMENT, List.of(make.DefaultCaseLabel()), List.of(thr), null);
-            cases = cases.append(c);
+            cases = cases.prepend(c);
         }
 
         return cases;

--- a/test/langtools/tools/javac/patterns/SealedTypeChanges.java
+++ b/test/langtools/tools/javac/patterns/SealedTypeChanges.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8270151
  * @summary Verify pattern switches work properly when the set of sealed types changes.
  * @compile --enable-preview -source ${jdk.version} SealedTypeChanges.java
  * @compile --enable-preview -source ${jdk.version} SealedTypeChanges2.java
@@ -43,6 +43,7 @@ public class SealedTypeChanges {
         doRun(this::statementIntf, this::validateIncompatibleClassChangeError);
         doRun(this::expressionCls, this::validateIncompatibleClassChangeError);
         doRun(this::statementCls, this::validateIncompatibleClassChangeError);
+        doRun(this::statementFallThrough, this::validateIncompatibleClassChangeError);
         doRun(this::expressionCoveredIntf, this::validateTestException);
         doRun(this::statementCoveredIntf, this::validateTestException);
         doRun(this::expressionCoveredCls, this::validateTestException);
@@ -86,6 +87,12 @@ public class SealedTypeChanges {
     void statementCls(SealedTypeChangesCls obj) {
         switch (obj) {
             case A a -> System.err.println(1);
+        }
+    }
+
+    void statementFallThrough(SealedTypeChangesCls obj) {
+        switch (obj) {
+            case A a: System.err.println(1);
         }
     }
 

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802 8269808
+ * @bug 8262891 8268333 8268896 8269802 8269808 8270151
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -73,6 +73,9 @@ public class Switches {
         npeTest(this::npeTestExpression);
         exhaustiveStatementSane("");
         exhaustiveStatementSane(null);
+        exhaustiveStatementSane2(null);
+        exhaustiveStatementSane2(new A());
+        exhaustiveStatementSane2(new B());
         switchNestingTest(this::switchNestingStatementStatement);
         switchNestingTest(this::switchNestingStatementExpression);
         switchNestingTest(this::switchNestingExpressionStatement);
@@ -449,6 +452,17 @@ public class Switches {
         }
         switch (o) {
             case Object obj, null:; //no break intentionally - should not fall through to any possible default
+        }
+    }
+
+    void exhaustiveStatementSane2(I i) {
+        switch (i) {
+            case A a: break;
+            case null, B b:; //no break intentionally - should not fall through to any possible default
+        }
+        switch (i) {
+            case A a -> {}
+            case null, B b -> {}
         }
     }
 


### PR DESCRIPTION
Consider code like:
```
sealed interface I {}
final class A implements I {}
...
I i = null;
switch (i) {
     case A a:
}
```

The switch is exhaustive, and javac must generate a synthetic default clause throwing an `IncompatibleClassChangeError` for the case where the permitted classes for I changes. The default clause is generated at the end of the switch statement, and consequently the execution will fall through from `case A a:` to this synthetic default, causing the `IncompatibleClassChangeError` for a valid input. (Note this was not a problem for switch expressions, as the last case can never complete normally for a switch expression.)

This PR proposes to put the synthetic default at the beginning of the switch statement, rather than at the end, which should avoid fall-through issues. An alternative solution would be to generate a synthetic break into the last case, but that is a bit tricky, so placing the default at the beginning seems more reliable to me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270151](https://bugs.openjdk.java.net/browse/JDK-8270151): IncompatibleClassChangeError on empty pattern switch statement case


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/237.diff">https://git.openjdk.java.net/jdk17/pull/237.diff</a>

</details>
