### PR TITLE
8269281: java/foreign/Test{Down,Up}call.java time out

### DIFF
--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -47,6 +47,8 @@ public class CallGeneratorHelper extends NativeTestHelper {
 
     static SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align, ResourceScope.newImplicitScope());
 
+    static final int SAMPLE_FACTOR = Integer.parseInt((String)System.getProperties().getOrDefault("generator.sample.factor", "-1"));
+
     static final int MAX_FIELDS = 3;
     static final int MAX_PARAMS = 3;
     static final int CHUNK_SIZE = 600;
@@ -199,7 +201,9 @@ public class CallGeneratorHelper extends NativeTestHelper {
                                 int count = functions;
                                 int fCode = functions++ / CHUNK_SIZE;
                                 String fName = String.format("f%d_%s_%s_%s", fCode, retCode, sigCode, structCode);
-                                downcalls.add(new Object[] { count, fName, r, ptypes, fields });
+                                if (SAMPLE_FACTOR == -1 || (count % SAMPLE_FACTOR) == 0) {
+                                    downcalls.add(new Object[]{count, fName, r, ptypes, fields});
+                                }
                             }
                         }
                     } else {
@@ -207,7 +211,9 @@ public class CallGeneratorHelper extends NativeTestHelper {
                         int count = functions;
                         int fCode = functions++ / CHUNK_SIZE;
                         String fName = String.format("f%d_%s_%s_%s", fCode, retCode, sigCode, structCode);
-                        downcalls.add(new Object[] { count, fName, r, ptypes, List.of() });
+                        if (SAMPLE_FACTOR == -1 || (count % SAMPLE_FACTOR) == 0) {
+                            downcalls.add(new Object[]{count, fName, r, ptypes, List.of()});
+                        }
                     }
                 }
             }

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -29,7 +29,7 @@
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
- *   --enable-native-access=ALL-UNNAMED
+ *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncall
  */
 
@@ -94,9 +94,6 @@ public class TestDowncall extends CallGeneratorHelper {
         FunctionDescriptor descriptor = function(ret, paramTypes, fields);
         Object[] args = makeArgs(paramTypes, fields, checks);
         boolean needsScope = mt.returnType().equals(MemorySegment.class);
-        if (count % 100 == 0) {
-            System.gc();
-        }
         Object res = doCall(addr, IMPLICIT_ALLOCATOR, mt, descriptor, args);
         if (ret == Ret.NON_VOID) {
             checks.forEach(c -> c.accept(res));

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -29,7 +29,7 @@
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
- *   --enable-native-access=ALL-UNNAMED
+ *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestUpcall
  */
 
@@ -41,7 +41,6 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 
 import jdk.incubator.foreign.ResourceScope;
-import jdk.incubator.foreign.SegmentAllocator;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -115,9 +114,6 @@ public class TestUpcall extends CallGeneratorHelper {
         MethodHandle mh = abi.downcallHandle(addr, IMPLICIT_ALLOCATOR, mtype, function(ret, paramTypes, fields));
         Object[] args = makeArgs(ResourceScope.newImplicitScope(), ret, paramTypes, fields, returnChecks, argChecks);
         Object[] callArgs = args;
-        if (count % 100 == 0) {
-            System.gc();
-        }
         Object res = mh.invokeWithArguments(callArgs);
         argChecks.forEach(c -> c.accept(args));
         if (ret == Ret.NON_VOID) {


### PR DESCRIPTION
After some more investigation, I have been able to at least partially reproduce on my Linux box. While I can't get to same slowdown as we're seeing in test machines, I did notice that in fastdebug mode, TestUpcall is a lot slower than in release mode.

The underlying issue is that these tests are generating a lot of "throwaway" method handles. Method handles are typically stored in fields - when that happens, creating a method handle with same shape as one that has already been created typically works ok, w/o overhead, because there's a cache in the MethodType class which stores already generated lambda forms (by method handle kind). This cache is a SofteReference cahce, so, if the system is under memory pressure, the GC is of course free to null out all these cached values, in which case a new lambda form will be generated, and a new class will be loaded.

When looking at both TestDowncall and TestUpcall, in their current form, it is possible to observe a fairly large amount of classes being loaded and unloaded. Since the test generates many garbage, the GC is under pressure, and that causes entries in the lambda form cache to be evicted. The fact that one of the tests also explicitly calls out to `System::gc` doesn't help, and probably adds to the churn.

Since it is very hard, if not impossible, to fix the test so that all the required method handle are retained for the entire duration of the test (since we create different variations of same handles, based on the test being run), I believe the best solution would be to reduce the number of test combinations being executed.

This patch adds the ability to specify a sampling factor - which reduces the size of the test combinations being executed. Note that we also have a fuller test (which is never run automatically, but can be ran by hand: `TestMatrix`) - this test does not specify any sampling factor, so when developers run this stress test manually they will still run the whole shebang (which is what you want if you are tweaking the logic in the foreign support).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269281](https://bugs.openjdk.java.net/browse/JDK-8269281): java/foreign/Test{Down,Up}call.java time out


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/238.diff">https://git.openjdk.java.net/jdk17/pull/238.diff</a>

</details>
