### PR TITLE
8270203: Missing build dependency between jdk.jfr-gendata and buildtools-hotspot

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -857,6 +857,9 @@ else
   # virtual target.
   jdk.jdwp.agent-libs: jdk.jdwp.agent-gensrc
 
+  # jdk.jfr-gensrc uses TOOL_JFR_GEN from buildtools-hotspot
+  jdk.jfr-gendata: buildtools-hotspot
+
   # The swing beans need to have java base properly generated to avoid errors
   # in javadoc. The X11 wrappers need the java.base include files to have been
   # copied and processed.

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -857,7 +857,7 @@ else
   # virtual target.
   jdk.jdwp.agent-libs: jdk.jdwp.agent-gensrc
 
-  # jdk.jfr-gensrc uses TOOL_JFR_GEN from buildtools-hotspot
+  # jdk.jfr-gendata uses TOOL_JFR_GEN from buildtools-hotspot
   jdk.jfr-gendata: buildtools-hotspot
 
   # The swing beans need to have java base properly generated to avoid errors


### PR DESCRIPTION
Add missing make dependency in Main.gmk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270203](https://bugs.openjdk.java.net/browse/JDK-8270203): Missing build dependency between jdk.jfr-gendata and buildtools-hotspot


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to 6e65e741aa26fb9a16f9652ea85e72ba503ea886


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/239.diff">https://git.openjdk.java.net/jdk17/pull/239.diff</a>

</details>
