### PR TITLE
8268635: Corrupt oop in ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -804,6 +804,7 @@ void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
   if (dest.resolve() != NULL) {
     return;
   } else {
+    record_modified_oops();
     dest = _handles.add(h());
   }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 3586a233 from the openjdk/jdk repository.

The commit being backported was authored by Coleen Phillimore on 7 Jul 2021 and was reviewed by Ioi Lam and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268635](https://bugs.openjdk.java.net/browse/JDK-8268635): Corrupt oop in ClassLoaderData


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/240.diff">https://git.openjdk.java.net/jdk17/pull/240.diff</a>

</details>
