### PR TITLE
8270025: DynamicCallSiteDesc::withArgs doesn't throw NPE

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
@@ -66,7 +66,7 @@ public class DynamicCallSiteDesc {
      * @param bootstrapArgs {@link ConstantDesc}s describing the static arguments
      *                      to the bootstrap, that would appear in the
      *                      {@code BootstrapMethods} attribute
-     * @throws NullPointerException if any parameter is null
+     * @throws NullPointerException if any parameter or its contents are {@code null}
      * @throws IllegalArgumentException if the invocation name has the incorrect
      * format
      * @jvms 4.2.2 Unqualified Names
@@ -79,6 +79,9 @@ public class DynamicCallSiteDesc {
         this.invocationType = requireNonNull(invocationType);
         this.bootstrapMethod = requireNonNull(bootstrapMethod);
         this.bootstrapArgs = requireNonNull(bootstrapArgs.clone());
+        for (int i = 0; i < this.bootstrapArgs.length; i++) {
+            requireNonNull(this.bootstrapArgs[i]);
+        }
         if (invocationName.length() == 0)
             throw new IllegalArgumentException("Illegal invocation name: " + invocationName);
     }
@@ -97,7 +100,7 @@ public class DynamicCallSiteDesc {
      *                      to the bootstrap, that would appear in the
      *                      {@code BootstrapMethods} attribute
      * @return the nominal descriptor
-     * @throws NullPointerException if any parameter is null
+     * @throws NullPointerException if any parameter or its contents are {@code null}
      * @throws IllegalArgumentException if the invocation name has the incorrect
      * format
      * @jvms 4.2.2 Unqualified Names

--- a/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
+++ b/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
@@ -62,19 +62,18 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                     "",
                     MethodTypeDesc.ofDescriptor("()I")
             );
-            throw new AssertionError("IllegalArgumentException expected");
+            fail("IllegalArgumentException expected");
         } catch (IllegalArgumentException iae) {
             // good
         }
 
-        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             DynamicCallSiteDesc.of(
                     null,
                     "getTarget",
                     MethodTypeDesc.ofDescriptor("()I")
             );
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -85,7 +84,7 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                     null,
                     MethodTypeDesc.ofDescriptor("()I")
             );
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -96,7 +95,7 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                     "getTarget",
                     null
             );
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -108,7 +107,7 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                     MethodTypeDesc.ofDescriptor("()I"),
                     null
             );
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -119,7 +118,7 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                     MethodTypeDesc.ofDescriptor("()I"),
                     new ConstantDesc[]{ null }
             );
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -135,17 +134,16 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
             MethodTypeDesc.ofDescriptor("()I")
         );
 
-        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             desc.withArgs(null);
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             desc.withArgs(new ConstantDesc[]{ null });
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
@@ -161,17 +159,16 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                 MethodTypeDesc.ofDescriptor("()I")
         );
 
-        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             desc.withNameAndType(null, MethodTypeDesc.ofDescriptor("()I"));
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             desc.withNameAndType("bootstrap", null);
-            throw ae;
+            fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             // good
         }

--- a/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
+++ b/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodType;
+import java.lang.constant.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.testng.annotations.Test;
+
+import static java.lang.constant.ConstantDescs.CD_int;
+import static java.lang.constant.ConstantDescs.CD_void;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * @test
+ * @compile DynamicCallSiteDescTest.java
+ * @run testng DynamicCallSiteDescTest
+ * @summary unit tests for java.lang.constant.DynamicCallSiteDesc
+ */
+
+@Test
+public class DynamicCallSiteDescTest extends SymbolicDescTest {
+    /* note there is no unit test for method resolveCallSiteDesc as it is being tested in another test in this
+     * suite, IndyDescTest
+     */
+
+    public void testOf() throws ReflectiveOperationException {
+        try {
+            DynamicCallSiteDesc.of(
+                    ConstantDescs.ofCallsiteBootstrap(
+                            ClassDesc.of("BootstrapAndTarget"),
+                            "bootstrap",
+                            ClassDesc.of("java.lang.invoke.CallSite")
+                    ),
+                    "",
+                    MethodTypeDesc.ofDescriptor("()I")
+            );
+            throw new AssertionError("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
+            // good
+        }
+
+        try {
+            DynamicCallSiteDesc.of(
+                    null,
+                    "getTarget",
+                    MethodTypeDesc.ofDescriptor("()I")
+            );
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+
+        try {
+            DynamicCallSiteDesc.of(
+                    ConstantDescs.ofCallsiteBootstrap(
+                            ClassDesc.of("BootstrapAndTarget"),
+                            "bootstrap",
+                            ClassDesc.of("java.lang.invoke.CallSite")
+                    ),
+                    null,
+                    MethodTypeDesc.ofDescriptor("()I")
+            );
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+
+        try {
+            DynamicCallSiteDesc.of(
+                    ConstantDescs.ofCallsiteBootstrap(
+                            ClassDesc.of("BootstrapAndTarget"),
+                            "bootstrap",
+                            ClassDesc.of("java.lang.invoke.CallSite")
+                    ),
+                    "getTarget",
+                    null
+            );
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+
+        try {
+            DynamicCallSiteDesc.of(
+                    ConstantDescs.ofCallsiteBootstrap(
+                            ClassDesc.of("BootstrapAndTarget"),
+                            "bootstrap",
+                            ClassDesc.of("java.lang.invoke.CallSite")
+                    ),
+                    "getTarget",
+                    MethodTypeDesc.ofDescriptor("()I"),
+                    null
+            );
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+        try {
+            DynamicCallSiteDesc.of(
+                    ConstantDescs.ofCallsiteBootstrap(
+                            ClassDesc.of("BootstrapAndTarget"),
+                            "bootstrap",
+                            ClassDesc.of("java.lang.invoke.CallSite")
+                    ),
+                    "getTarget",
+                    MethodTypeDesc.ofDescriptor("()I"),
+                    new ConstantDesc[]{ null }
+            );
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+    }
+
+    public void testWithArgs() throws ReflectiveOperationException {
+        DynamicCallSiteDesc desc = DynamicCallSiteDesc.of(ConstantDescs.ofCallsiteBootstrap(
+                ClassDesc.of("BootstrapAndTarget"),
+                "bootstrap",
+                ClassDesc.of("java.lang.invoke.CallSite")
+            ),
+            "getTarget",
+            MethodTypeDesc.ofDescriptor("()I")
+        );
+
+        try {
+            desc.withArgs(null);
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+
+        try {
+            desc.withArgs(new ConstantDesc[]{ null });
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+    }
+
+    public void testWithNameAndType() throws ReflectiveOperationException {
+        DynamicCallSiteDesc desc = DynamicCallSiteDesc.of(ConstantDescs.ofCallsiteBootstrap(
+                ClassDesc.of("BootstrapAndTarget"),
+                "bootstrap",
+                ClassDesc.of("java.lang.invoke.CallSite")
+                ),
+                "getTarget",
+                MethodTypeDesc.ofDescriptor("()I")
+        );
+
+        try {
+            desc.withNameAndType(null, MethodTypeDesc.ofDescriptor("()I"));
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+
+        try {
+            desc.withNameAndType("bootstrap", null);
+            throw new AssertionError("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // good
+        }
+    }
+
+    public void testAccessorsAndFactories() throws ReflectiveOperationException {
+        DynamicCallSiteDesc desc = DynamicCallSiteDesc.of(ConstantDescs.ofCallsiteBootstrap(
+                ClassDesc.of("BootstrapAndTarget"),
+                "bootstrap",
+                ClassDesc.of("java.lang.invoke.CallSite")
+                ),
+                "_",
+                MethodTypeDesc.ofDescriptor("()I")
+        );
+        assertEquals(desc, DynamicCallSiteDesc.of((DirectMethodHandleDesc)desc.bootstrapMethod(), desc.invocationType()));
+        assertEquals(desc, DynamicCallSiteDesc.of((DirectMethodHandleDesc)desc.bootstrapMethod(),
+                desc.invocationName(), desc.invocationType()));
+        assertEquals(desc, DynamicCallSiteDesc.of((DirectMethodHandleDesc)desc.bootstrapMethod(),
+                desc.invocationName(), desc.invocationType(), desc.bootstrapArgs()));
+    }
+}

--- a/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
+++ b/test/jdk/java/lang/constant/DynamicCallSiteDescTest.java
@@ -51,13 +51,14 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
      */
 
     public void testOf() throws ReflectiveOperationException {
+        DirectMethodHandleDesc dmh = ConstantDescs.ofCallsiteBootstrap(
+                ClassDesc.of("BootstrapAndTarget"),
+                "bootstrap",
+                ClassDesc.of("java.lang.invoke.CallSite")
+        );
         try {
             DynamicCallSiteDesc.of(
-                    ConstantDescs.ofCallsiteBootstrap(
-                            ClassDesc.of("BootstrapAndTarget"),
-                            "bootstrap",
-                            ClassDesc.of("java.lang.invoke.CallSite")
-                    ),
+                    dmh,
                     "",
                     MethodTypeDesc.ofDescriptor("()I")
             );
@@ -66,74 +67,59 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
             // good
         }
 
+        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             DynamicCallSiteDesc.of(
                     null,
                     "getTarget",
                     MethodTypeDesc.ofDescriptor("()I")
             );
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             DynamicCallSiteDesc.of(
-                    ConstantDescs.ofCallsiteBootstrap(
-                            ClassDesc.of("BootstrapAndTarget"),
-                            "bootstrap",
-                            ClassDesc.of("java.lang.invoke.CallSite")
-                    ),
+                    dmh,
                     null,
                     MethodTypeDesc.ofDescriptor("()I")
             );
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             DynamicCallSiteDesc.of(
-                    ConstantDescs.ofCallsiteBootstrap(
-                            ClassDesc.of("BootstrapAndTarget"),
-                            "bootstrap",
-                            ClassDesc.of("java.lang.invoke.CallSite")
-                    ),
+                    dmh,
                     "getTarget",
                     null
             );
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             DynamicCallSiteDesc.of(
-                    ConstantDescs.ofCallsiteBootstrap(
-                            ClassDesc.of("BootstrapAndTarget"),
-                            "bootstrap",
-                            ClassDesc.of("java.lang.invoke.CallSite")
-                    ),
+                    dmh,
                     "getTarget",
                     MethodTypeDesc.ofDescriptor("()I"),
                     null
             );
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
         try {
             DynamicCallSiteDesc.of(
-                    ConstantDescs.ofCallsiteBootstrap(
-                            ClassDesc.of("BootstrapAndTarget"),
-                            "bootstrap",
-                            ClassDesc.of("java.lang.invoke.CallSite")
-                    ),
+                    dmh,
                     "getTarget",
                     MethodTypeDesc.ofDescriptor("()I"),
                     new ConstantDesc[]{ null }
             );
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
@@ -149,16 +135,17 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
             MethodTypeDesc.ofDescriptor("()I")
         );
 
+        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             desc.withArgs(null);
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             desc.withArgs(new ConstantDesc[]{ null });
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
@@ -174,16 +161,17 @@ public class DynamicCallSiteDescTest extends SymbolicDescTest {
                 MethodTypeDesc.ofDescriptor("()I")
         );
 
+        AssertionError ae = new AssertionError("NullPointerException expected");
         try {
             desc.withNameAndType(null, MethodTypeDesc.ofDescriptor("()I"));
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }
 
         try {
             desc.withNameAndType("bootstrap", null);
-            throw new AssertionError("NullPointerException expected");
+            throw ae;
         } catch (NullPointerException npe) {
             // good
         }


### PR DESCRIPTION
Please review this PR that is fixing a mismatch between the implementation for method `java.lang.constant.DynamicCallSiteDesc::withArgs` and its implementation. I made a mistake while working on a recent CSR [JDK-8224985](https://bugs.openjdk.java.net/browse/JDK-8224985) and fixed the API but mistakenly thought that the implementation was in sync with the spec. This is why this change is also including a unit test of the API for `java.lang.constant.DynamicCallSiteDesc` modulo method `resolveCallSiteDesc` which is covered in test `IndyDescTest` in the same test suite. Also this change needs a CSR as while fixing the implementation of method `::withArgs` I realized that the API of the varargs overloaded version of method `::of` needed some rewording too as it is invoking the same private constructor `::withArgs` is invoking. So it didn't make sense for the API of one method to be more restrictive than the other. Please review also the accompanying CSR.

Thanks,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270025](https://bugs.openjdk.java.net/browse/JDK-8270025): DynamicCallSiteDesc::withArgs doesn't throw NPE


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to 602a85c4612cffd4191d4bd55c092ef8136aabd8
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/242.diff">https://git.openjdk.java.net/jdk17/pull/242.diff</a>

</details>
