### PR TITLE
8266889: [macosx-aarch64] Crash with SIGBUS in MarkActivationClosure::do_code_blob during vmTestbase/nsk/jvmti/.../bi04t002 test run

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -3144,7 +3144,9 @@ JvmtiEnv::RawMonitorEnter(JvmtiRawMonitor * rmonitor) {
     // in thread.cpp.
     JvmtiPendingMonitors::enter(rmonitor);
   } else {
-    rmonitor->raw_enter(Thread::current());
+    Thread* thread = Thread::current();
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    rmonitor->raw_enter(thread);
   }
   return JVMTI_ERROR_NONE;
 } /* end RawMonitorEnter */
@@ -3163,6 +3165,7 @@ JvmtiEnv::RawMonitorExit(JvmtiRawMonitor * rmonitor) {
     }
   } else {
     Thread* thread = Thread::current();
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     int r = rmonitor->raw_exit(thread);
     if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {
       err = JVMTI_ERROR_NOT_MONITOR_OWNER;
@@ -3176,6 +3179,7 @@ JvmtiEnv::RawMonitorExit(JvmtiRawMonitor * rmonitor) {
 jvmtiError
 JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
   Thread* thread = Thread::current();
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_wait(millis, thread);
 
   switch (r) {
@@ -3193,6 +3197,7 @@ JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
 jvmtiError
 JvmtiEnv::RawMonitorNotify(JvmtiRawMonitor * rmonitor) {
   Thread* thread = Thread::current();
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_notify(thread);
 
   if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {
@@ -3206,6 +3211,7 @@ JvmtiEnv::RawMonitorNotify(JvmtiRawMonitor * rmonitor) {
 jvmtiError
 JvmtiEnv::RawMonitorNotifyAll(JvmtiRawMonitor * rmonitor) {
   Thread* thread = Thread::current();
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_notifyAll(thread);
 
   if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -3145,6 +3145,7 @@ JvmtiEnv::RawMonitorEnter(JvmtiRawMonitor * rmonitor) {
     JvmtiPendingMonitors::enter(rmonitor);
   } else {
     Thread* thread = Thread::current();
+    // 8266889: raw_enter changes Java thread state, needs WXWrite
     MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     rmonitor->raw_enter(thread);
   }
@@ -3165,7 +3166,6 @@ JvmtiEnv::RawMonitorExit(JvmtiRawMonitor * rmonitor) {
     }
   } else {
     Thread* thread = Thread::current();
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     int r = rmonitor->raw_exit(thread);
     if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {
       err = JVMTI_ERROR_NOT_MONITOR_OWNER;
@@ -3179,6 +3179,7 @@ JvmtiEnv::RawMonitorExit(JvmtiRawMonitor * rmonitor) {
 jvmtiError
 JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
   Thread* thread = Thread::current();
+  // 8266889: raw_wait changes Java thread state, needs WXWrite
   MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_wait(millis, thread);
 
@@ -3197,7 +3198,6 @@ JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
 jvmtiError
 JvmtiEnv::RawMonitorNotify(JvmtiRawMonitor * rmonitor) {
   Thread* thread = Thread::current();
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_notify(thread);
 
   if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {
@@ -3211,7 +3211,6 @@ JvmtiEnv::RawMonitorNotify(JvmtiRawMonitor * rmonitor) {
 jvmtiError
 JvmtiEnv::RawMonitorNotifyAll(JvmtiRawMonitor * rmonitor) {
   Thread* thread = Thread::current();
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_notifyAll(thread);
 
   if (r == JvmtiRawMonitor::M_ILLEGAL_MONITOR_STATE) {


### PR DESCRIPTION
The change adds W^X transition in RawMonitor family of functions, fixing the crash. RawMonitor functions are treated specially, so W^X transition is not inserted automatically. A better fix would be in .xml description for entries generation, but for now it is too risky. I hope to get this fixed in 17 in the simplest way and do re-work in the 18. This change is still 100% correct for the reported bug.

Verified by: 
```
jtreg -vmoption:-XX:+AssertWXAtThreadSync test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266889](https://bugs.openjdk.java.net/browse/JDK-8266889): [macosx-aarch64] Crash with SIGBUS in MarkActivationClosure::do_code_blob during vmTestbase/nsk/jvmti/.../bi04t002 test run


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/244.diff">https://git.openjdk.java.net/jdk17/pull/244.diff</a>

</details>
