### PR TITLE
8270184: [TESTBUG] Add coverage for jvmci ResolvedJavaType.toJavaName() for lambdas

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -163,6 +163,19 @@ public class TestResolvedJavaType extends TypeUniverse {
     }
 
     @Test
+    public void internalNameTest() {
+        // Verify that the last slash in lambda types are not replaced with a '.' as they
+        // are part of the type name.
+        Supplier<Runnable> lambda = () -> () -> System.out.println("run");
+        ResolvedJavaType lambdaType = metaAccess.lookupJavaType(lambda.getClass());
+        String typeName = lambdaType.getName();
+        int typeNameLen = TestResolvedJavaType.class.getSimpleName().length();
+        int index = typeName.indexOf(TestResolvedJavaType.class.getSimpleName());
+        String suffix = typeName.substring(index + typeNameLen, typeName.length() - 1);
+        assertEquals(TestResolvedJavaType.class.getName() + suffix, lambdaType.toJavaName());
+    }
+
+    @Test
     public void getModifiersTest() {
         for (Class<?> c : classes) {
             ResolvedJavaType type = metaAccess.lookupJavaType(c);


### PR DESCRIPTION
Clean backport. Test-only change. Test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270184](https://bugs.openjdk.java.net/browse/JDK-8270184): [TESTBUG] Add coverage for jvmci ResolvedJavaType.toJavaName() for lambdas


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/246/head:pull/246` \
`$ git checkout pull/246`

Update a local copy of the PR: \
`$ git checkout pull/246` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 246`

View PR using the GUI difftool: \
`$ git pr show -t 246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/246.diff">https://git.openjdk.java.net/jdk17/pull/246.diff</a>

</details>
