### PR TITLE
8270422: Test build/AbsPathsInImage.java fails after JDK-8259848

### DIFF
--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -213,12 +213,12 @@ endif
 
 ifeq ($(call isTargetOs, windows), true)
   ifeq ($(SHIP_DEBUG_SYMBOLS), )
-    JMOD_FLAGS += --exclude '**{_the.*,_*.marker,*.diz,*.pdb,*.map}'
+    JMOD_FLAGS += --exclude '**{_the.*,_*.marker*,*.diz,*.pdb,*.map}'
   else
-    JMOD_FLAGS += --exclude '**{_the.*,_*.marker,*.diz,*.map}'
+    JMOD_FLAGS += --exclude '**{_the.*,_*.marker*,*.diz,*.map}'
   endif
 else
-  JMOD_FLAGS += --exclude '**{_the.*,_*.marker,*.diz,*.debuginfo,*.dSYM/**,*.dSYM}'
+  JMOD_FLAGS += --exclude '**{_the.*,_*.marker*,*.diz,*.debuginfo,*.dSYM/**,*.dSYM}'
 endif
 
 # Create jmods in the support dir and then move them into place to keep the


### PR DESCRIPTION
This patch extends the filter for marker files when creating jmods. Our latest established marker file format is `_*.marker` and through ExecuteWithLog, we regularly append additional suffixes to such file names. Thus I propose we simply extend the filter pattern to `_*.marker*`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270422](https://bugs.openjdk.java.net/browse/JDK-8270422): Test build/AbsPathsInImage.java fails after JDK-8259848


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/249.diff">https://git.openjdk.java.net/jdk17/pull/249.diff</a>

</details>
