### PR TITLE
8270461: ZGC: Invalid oop passed to ZBarrierSetRuntime::load_barrier_on_oop_array

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -296,6 +296,13 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
     Node* dest_offset = ac->in(ArrayCopyNode::DestPos);
     Node* length = ac->in(ArrayCopyNode::Length);
 
+    if (bt == T_OBJECT) {
+      // BarrierSetC2::arraycopy_payload_base_offset 8-byte aligns the offset.
+      // Make sure the offset points to the first element in the array when cloning
+      // object arrays. Otherwise, load barriers are applied to parts of the header.
+      src_offset = phase->longcon(arrayOopDesc::base_offset_in_bytes(T_OBJECT));
+      dest_offset = src_offset;
+    }
     Node* payload_src = phase->basic_plus_adr(src, src_offset);
     Node* payload_dst = phase->basic_plus_adr(dest, dest_offset);
 

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -297,9 +297,10 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
     Node* length = ac->in(ArrayCopyNode::Length);
 
     if (bt == T_OBJECT) {
-      // BarrierSetC2::arraycopy_payload_base_offset 8-byte aligns the offset.
-      // Make sure the offset points to the first element in the array when cloning
-      // object arrays. Otherwise, load barriers are applied to parts of the header.
+      // BarrierSetC2::clone sets the offsets via BarrierSetC2::arraycopy_payload_base_offset
+      // which 8-byte aligns them to allow for word size copies. Make sure the offsets point
+      // to the first element in the array when cloning object arrays. Otherwise, load
+      // barriers are applied to parts of the header.
       assert(src_offset == dest_offset, "should be equal");
       assert((src_offset->get_long() == arrayOopDesc::base_offset_in_bytes(T_OBJECT) && UseCompressedClassPointers) ||
              (src_offset->get_long() == arrayOopDesc::length_offset_in_bytes() && !UseCompressedClassPointers),

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -300,6 +300,10 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
       // BarrierSetC2::arraycopy_payload_base_offset 8-byte aligns the offset.
       // Make sure the offset points to the first element in the array when cloning
       // object arrays. Otherwise, load barriers are applied to parts of the header.
+      assert(src_offset == dest_offset, "should be equal");
+      assert((src_offset->get_long() == arrayOopDesc::base_offset_in_bytes(T_OBJECT) && UseCompressedClassPointers) ||
+             (src_offset->get_long() == arrayOopDesc::length_offset_in_bytes() && !UseCompressedClassPointers),
+             "unexpected offset for object array clone");
       src_offset = phase->longcon(arrayOopDesc::base_offset_in_bytes(T_OBJECT));
       dest_offset = src_offset;
     }

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -307,8 +307,8 @@ address PhaseMacroExpand::basictype2arraycopy(BasicType t,
                                               bool disjoint_bases,
                                               const char* &name,
                                               bool dest_uninitialized) {
-  const TypeInt* src_offset_inttype  = _igvn.find_int_type(src_offset);;
-  const TypeInt* dest_offset_inttype = _igvn.find_int_type(dest_offset);;
+  const TypeInt* src_offset_inttype  = _igvn.find_int_type(src_offset);
+  const TypeInt* dest_offset_inttype = _igvn.find_int_type(dest_offset);
 
   bool aligned = false;
   bool disjoint = disjoint_bases;

--- a/test/hotspot/jtreg/compiler/arraycopy/TestObjectArrayClone.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestObjectArrayClone.java
@@ -23,14 +23,15 @@
 
 /*
  * @test
- * @bug 8155643
- * @summary Test Object.clone() intrinsic if ReduceInitialCardMarks is disabled.
+ * @bug 8155643 8268125 8270461
+ * @summary Test Object.clone() intrinsic.
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-ReduceInitialCardMarks
  *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestObjectArrayClone::testClone*
  *                   compiler.arraycopy.TestObjectArrayClone
- *
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.arraycopy.TestObjectArrayClone::testClone*
+ *                   compiler.arraycopy.TestObjectArrayClone
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedClassPointers -Xmx128m
  *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestObjectArrayClone::testClone*
  *                   compiler.arraycopy.TestObjectArrayClone
  */


### PR DESCRIPTION
For object arrays, C2's clone intrinsic emits calls to the `oop_disjoint_arraycopy_uninit` stub. With ZGC, load barriers on the source array elements are applied via `BarrierSetAssembler::arraycopy_prologue` before copying to the destination array: https://github.com/openjdk/jdk17/blob/1e3b418a53a080a53827989393362338b43dd363/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp#L2400-L2403

The problem is that `BarrierSetC2::arraycopy_payload_base_offset` may 8-byte align the array offset to ensure that a copy in 8-byte chunks of the 8-byte aligned object is possible: https://github.com/openjdk/jdk17/blob/1e3b418a53a080a53827989393362338b43dd363/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp#L658-L662
Now with ` -XX:-UseCompressedClassPointers`, the offset starts at the 4-byte length field of the array (8 bytes mark word + 8 byte klass = 16 byte). That is fine if we don't need load barriers and can copy the array as `T_LONG` but with ZGC we crash in `ZBarrier::mark` because the element is not a valid oop.

I propose to simply set the offset to the first array element when cloning Object arrays with ZGC. We can still copy in 8 byte chunks because the oop elements are 8 byte on 64-bit (and ZGC is only supported on 64-bit).

I found this when investigating intermittent ZGC crashes in project Valhalla. The bug was introduced by [JDK-8268125](https://bugs.openjdk.java.net/browse/JDK-8268125) in JDK 17. The code is quite messy and will hopefully be cleaned up by [JDK-8268020](https://bugs.openjdk.java.net/browse/JDK-8268020).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270461](https://bugs.openjdk.java.net/browse/JDK-8270461): ZGC: Invalid oop passed to ZBarrierSetRuntime::load_barrier_on_oop_array


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/252.diff">https://git.openjdk.java.net/jdk17/pull/252.diff</a>

</details>
