### PR TITLE
8270858: Problem List java/awt/Window/MultiWindowApp/MultiWindowAppTest.java on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -226,6 +226,7 @@ java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java 8196440 linux-all
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java 8197936 macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeDynamicallyAndClick.java 8013450 macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucentWindowClick.java 8013450 macosx-all
+java/awt/Window/MultiWindowApp/MultiWindowAppTest.java 8159904 linux-all
 java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java 8222323 windows-all
 java/awt/Window/ShapedAndTranslucentWindows/FocusAWTTest.java 8222328 windows-all,linux-all,macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/Shaped.java  8222328 windows-all,linux-all,macosx-all


### PR DESCRIPTION
Failing too often on Ubuntu 21.04 so creating noise in the system. 
We need to look at whether there's a product issue or a system config issue but it still needs to be problem listed.
Per the RDP 2 rules no approval is needed to problem list a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270858](https://bugs.openjdk.java.net/browse/JDK-8270858): Problem List  java/awt/Window/MultiWindowApp/MultiWindowAppTest.java on Linux


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/253.diff">https://git.openjdk.java.net/jdk17/pull/253.diff</a>

</details>
