### PR TITLE
8270307: C2: assert(false) failed: bad AD file after JDK-8267687

### DIFF
--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -155,6 +155,9 @@ const Type* CMoveNode::Value(PhaseGVN* phase) const {
   if (phase->type(in(Condition)) == Type::TOP) {
     return Type::TOP;
   }
+  if (phase->type(in(IfTrue)) == Type::TOP || phase->type(in(IfFalse)) == Type::TOP) {
+    return Type::TOP;
+  }
   const Type* t = phase->type(in(IfFalse))->meet_speculative(phase->type(in(IfTrue)));
   return t->filter(_type);
 }

--- a/test/hotspot/jtreg/compiler/c2/TestCMoveHasTopInput.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCMoveHasTopInput.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8270307
+ * @summary C2: assert(false) failed: bad AD file after JDK-8267687
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestCMoveHasTopInput.vMeth TestCMoveHasTopInput
+ */
+
+public class TestCMoveHasTopInput {
+    public static boolean arr[] = new boolean[20];
+
+    public void vMeth(long l) {
+        for (int a = 2; a < 155; a++) {
+            for (int b = 1; b < 10; ++b) {
+                for (int c = 1; c < 2; c++) {
+                    l += 3 * l;
+                    arr[b - 1] = false;
+                    switch (a) {
+                        case 14:
+                        case 17:
+                            l -= b;
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        TestCMoveHasTopInput test = new TestCMoveHasTopInput();
+        for (int i = 0; i < 10; i++) {
+            test.vMeth(i);
+        }
+    }
+}


### PR DESCRIPTION
One input of ConvI2L becomes Top, which causes all nodes in the chain becoming Top, but this CMoveLNode does not change, only its input becomes Top.
```
  Pop  2146  CMoveL  === _  351  1  2149  [[ 2182  2187 ]]   Type:long !orig=810,696,[439],288 !jvms: Test::vMeth @ bci:78 (line 8)
BreakAtNode: _idx=2461 _debug_idx=102702461 orig._idx=2146 orig._debug_idx=92502146
<               < 2146  CMoveL  === _ _  1 _  [[]]   Type:long !orig=810,696,[439],288 !jvms: Test::vMeth @ bci:78 (line 8)
> long           2461  CMoveL  === _  2458  2149  1  [[ 2187  2182 ]]   Type:long !orig=2146,810,696,[439],288 !jvms: Test::vMeth @ bci:78 (line 8)
```
This CMoveLNode(CMove Binary(.. ..) (Binary .. Con#Top)) can not match any rules in the instruction selection phase and finally hits the assert. The proposed fix disables further optimizations if inputs of CMoveNode are type of Top.

Testing:
- test/hotspot/jtreg/compiler/c2
- github presubmit tests
- attached fuzzer test
- TestCMoveHasTopInput

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270307](https://bugs.openjdk.java.net/browse/JDK-8270307): C2: assert(false) failed: bad AD file after JDK-8267687


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Contributors
 * Kuai Wei `<kuaiwei.kw@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/254/head:pull/254` \
`$ git checkout pull/254`

Update a local copy of the PR: \
`$ git checkout pull/254` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 254`

View PR using the GUI difftool: \
`$ git pr show -t 254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/254.diff">https://git.openjdk.java.net/jdk17/pull/254.diff</a>

</details>
