### PR TITLE
8269820: C2 PhaseIdealLoop::do_unroll get wrong opaque node

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1396,6 +1396,18 @@ static bool is_counted_loop_cmp(Node *cmp) {
          n->in(0)->as_CountedLoop()->phi() == n;
 }
 
+static bool is_phi_has_opaque1(Node* n) {
+  if (n->is_Phi()) {
+    for (uint i = 1; i < n->req(); i++) {
+      Node* in = n->in(i);
+      if (in != NULL && in->is_Opaque1()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 //------------------------------Ideal------------------------------------------
 Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Change "bool tst (cmp con x)" into "bool ~tst (cmp x con)".
@@ -1418,7 +1430,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Move constants to the right of compare's to canonicalize.
   // Do not muck with Opaque1 nodes, as this indicates a loop
   // guard that cannot change shape.
-  if( con->is_Con() && !cmp2->is_Con() && op2 != Op_Opaque1 &&
+  if( con->is_Con() && !cmp2->is_Con() && op2 != Op_Opaque1 && !is_phi_has_opaque1(cmp2) &&
       // Because of NaN's, CmpD and CmpF are not commutative
       cop != Op_CmpD && cop != Op_CmpF &&
       // Protect against swapping inputs to a compare when it is used by a

--- a/test/hotspot/jtreg/compiler/loopopts/TestCanonicalLoopEntryOpaqueOrder.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCanonicalLoopEntryOpaqueOrder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8269820
+ * @requires vm.compiler2.enabled
+ * @summary oqaue node in canonical_loop_entry's input chain is not fixed at
+ *          compare node's in(2).
+ * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.loopopts.TestCanonicalLoopEntryOpaqueOrder
+ */
+
+package compiler.loopopts;
+public class TestCanonicalLoopEntryOpaqueOrder {
+    static void test() {
+        int ina8[] = new int[1478];
+        int in2 = 136;
+        long lo3 = 0L;
+        try {
+            for (int i = 0; i < 34; i++) {
+                Math.log1p(1);
+            }
+        } catch (Exception e) {
+            in2 = 1;
+        }
+
+        for (int i = 0; i < in2; i++) {
+            if (in2 > 10) {  // split if and create wrong opaque order
+                for (int j = 0; j < in2; j++) {
+                    lo3 -= 1L;
+                }
+            }
+        }
+    }
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
More discussion in previous PR(https://github.com/openjdk/jdk17/pull/208) is confilict with fix for JDK-8269752.

Opaque1 in main loop entry is expected only used in compare node's second input. However split if might clone opaque1 and replace original node with phi of opaque1 node. This causes assertion in CountedLoopNode::is_canonical_loop_entry now.

Fix is in BoolNode::Ideal, avoiding switching compare node's input when second input is phi of opaque1.

Test: Linux X64 tier1/2/3 release/fastdebug no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269820](https://bugs.openjdk.java.net/browse/JDK-8269820): C2 PhaseIdealLoop::do_unroll get wrong opaque node


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/255.diff">https://git.openjdk.java.net/jdk17/pull/255.diff</a>

</details>
