### PR TITLE
8270916: Update java.lang.annotation.Target for changes in JLS 9.6.4.1

### DIFF
--- a/src/java.base/share/classes/java/lang/annotation/Target.java
+++ b/src/java.base/share/classes/java/lang/annotation/Target.java
@@ -28,16 +28,16 @@ package java.lang.annotation;
 /**
  * Indicates the contexts in which an annotation interface is applicable. The
  * declaration contexts and type contexts in which an annotation interface may
- * be applicable are specified in JLS 9.6.4.1, and denoted in source code by
+ * be applicable are specified in JLS {@jls 9.6.4.1}, and denoted in source code by
  * enum constants of {@link ElementType java.lang.annotation.ElementType}.
  *
  * <p>If an {@code @Target} meta-annotation is not present on an annotation
  * interface {@code T}, then an annotation of type {@code T} may be written as
- * a modifier for any declaration except a type parameter declaration.
+ * a modifier for any declaration.
  *
  * <p>If an {@code @Target} meta-annotation is present, the compiler will enforce
  * the usage restrictions indicated by {@code ElementType}
- * enum constants, in line with JLS 9.7.4.
+ * enum constants, in line with JLS {@jls 9.7.4}.
  *
  * <p>For example, this {@code @Target} meta-annotation indicates that the
  * declared interface is itself a meta-annotation interface.  It can only be


### PR DESCRIPTION
Given changes in JLS 9.6.4.1, JDK-8261610 in Java SE 17, the statements about annotation applicability made in java.lang.annotation.Target need to be updated to match.

Please also review the corresponding CSR: https://bugs.openjdk.java.net/browse/JDK-8270917

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270916](https://bugs.openjdk.java.net/browse/JDK-8270916): Update java.lang.annotation.Target for changes in JLS 9.6.4.1


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/256/head:pull/256` \
`$ git checkout pull/256`

Update a local copy of the PR: \
`$ git checkout pull/256` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 256`

View PR using the GUI difftool: \
`$ git pr show -t 256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/256.diff">https://git.openjdk.java.net/jdk17/pull/256.diff</a>

</details>
