### PR TITLE
8159904: [TEST_BUG] Failure on solaris of java/awt/Window/MultiWindowApp/MultiWindowAppTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -226,7 +226,6 @@ java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java 8196440 linux-all
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java 8197936 macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeDynamicallyAndClick.java 8013450 macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucentWindowClick.java 8013450 macosx-all
-java/awt/Window/MultiWindowApp/MultiWindowAppTest.java 8159904 linux-all
 java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java 8222323 windows-all
 java/awt/Window/ShapedAndTranslucentWindows/FocusAWTTest.java 8222328 windows-all,linux-all,macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/Shaped.java  8222328 windows-all,linux-all,macosx-all

--- a/test/jdk/java/awt/Window/MultiWindowApp/MultiWindowAppTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/MultiWindowAppTest.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @summary After calling frame.toBack() dialog goes to the back on Ubuntu 12.04
  * @key headful
@@ -38,22 +38,24 @@ public class MultiWindowAppTest {
         Window win1 = new Frame();
         Window win2 = new Dialog((Frame) null);
 
+        int delay = 300;
+
         win1.setBounds(100, 100, 200, 200);
         win1.setBackground(Color.RED);
         win1.setVisible(true);
 
         Robot robot = new Robot();
-        robot.delay(200);
+        robot.delay(delay);
         robot.waitForIdle();
 
         win2.setBounds(win1.getBounds());
         win2.setVisible(true);
 
-        robot.delay(200);
+        robot.delay(delay);
         robot.waitForIdle();
 
         win1.toFront();
-        robot.delay(200);
+        robot.delay(delay);
         robot.waitForIdle();
 
         Point point = win1.getLocationOnScreen();
@@ -66,7 +68,7 @@ public class MultiWindowAppTest {
         }
 
         win1.toBack();
-        robot.delay(200);
+        robot.delay(delay);
         robot.waitForIdle();
 
         color = robot.getPixelColor(point.x + 100, point.y + 100);


### PR DESCRIPTION
This is the same fix as https://github.com/openjdk/jdk/pull/4830 , but retargeted to jdk17.

> This test can fail pretty consistently on some slow systems. Increased delay fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8159904](https://bugs.openjdk.java.net/browse/JDK-8159904): [TEST_BUG] Failure on solaris of java/awt/Window/MultiWindowApp/MultiWindowAppTest.java


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/260.diff">https://git.openjdk.java.net/jdk17/pull/260.diff</a>

</details>
