### PR TITLE
8270491: SEGV at read_string_field(oopDesc*, char const*, JavaThread*)+0x54

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
@@ -31,23 +31,23 @@ class JfrJavaArguments;
 class JfrDCmd : public DCmd {
  private:
   const char* _args;
+  const int _num_arguments;
   char _delimiter;
+ protected:
+  JfrDCmd(outputStream* output, bool heap, int num_arguments);
+  virtual const char* javaClass() const = 0;
+  void invoke(JfrJavaArguments& method, TRAPS) const;
  public:
-  JfrDCmd(outputStream* output, bool heap) : DCmd(output,heap), _args(NULL), _delimiter('\0')  {}
-
   virtual void execute(DCmdSource source, TRAPS);
   virtual void print_help(const char* name) const;
   virtual GrowableArray<const char*>* argument_name_array() const;
   virtual GrowableArray<DCmdArgumentInfo*>* argument_info_array() const;
   virtual void parse(CmdLine* line, char delim, TRAPS);
- protected:
-  virtual const char* javaClass() const = 0;
-  void invoke(JfrJavaArguments& method, TRAPS) const;
 };
 
 class JfrStartFlightRecordingDCmd : public JfrDCmd {
  public:
-  JfrStartFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap) {}
+  JfrStartFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap, num_arguments()) {}
 
   static const char* name() {
     return "JFR.start";
@@ -72,7 +72,7 @@ class JfrStartFlightRecordingDCmd : public JfrDCmd {
 
 class JfrDumpFlightRecordingDCmd : public JfrDCmd {
  public:
-  JfrDumpFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap) {}
+  JfrDumpFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap, num_arguments()) {}
 
   static const char* name() {
     return "JFR.dump";
@@ -97,7 +97,7 @@ class JfrDumpFlightRecordingDCmd : public JfrDCmd {
 
 class JfrCheckFlightRecordingDCmd : public JfrDCmd {
  public:
-  JfrCheckFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap) {}
+  JfrCheckFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap, num_arguments()) {}
 
   static const char* name() {
     return "JFR.check";
@@ -122,7 +122,7 @@ class JfrCheckFlightRecordingDCmd : public JfrDCmd {
 
 class JfrStopFlightRecordingDCmd : public JfrDCmd {
  public:
-  JfrStopFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap) {}
+  JfrStopFlightRecordingDCmd(outputStream* output, bool heap) : JfrDCmd(output, heap, num_arguments()) {}
 
   static const char* name() {
     return "JFR.stop";


### PR DESCRIPTION
Greetings,

Please help review this changeset which adds missing logic to handle potential exceptions when retrieving the MBean argument descriptors for the JFR diagnostic commands.

Testing: jdk_jfr, perfstartup

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270491](https://bugs.openjdk.java.net/browse/JDK-8270491): SEGV at read_string_field(oopDesc*, char const*, JavaThread*)+0x54


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/261.diff">https://git.openjdk.java.net/jdk17/pull/261.diff</a>

</details>
