### PR TITLE
JDK-8270866: NPE in DocTreePath.getTreePath()

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -335,7 +335,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
                     : HtmlLinkInfo.Kind.MEMBER,
                     te, element, typeContent);
             Content desc = new ContentBuilder();
-            writer.addSummaryLinkComment(this, element, desc);
+            writer.addSummaryLinkComment(element, desc);
             useTable.addRow(summaryType, typeContent, desc);
         }
         contentTree.add(useTable);
@@ -363,7 +363,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
         addSummaryLink(tElement, member, summaryLink);
         rowContents.add(summaryLink);
         Content desc = new ContentBuilder();
-        writer.addSummaryLinkComment(this, member, firstSentenceTrees, desc);
+        writer.addSummaryLinkComment(member, firstSentenceTrees, desc);
         rowContents.add(desc);
         table.addRow(member, rowContents);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1162,7 +1162,7 @@ public class HtmlDocletWriter {
     public void addInlineComment(Element element, DocTree tag, Content htmltree) {
         CommentHelper ch = utils.getCommentHelper(element);
         List<? extends DocTree> description = ch.getDescription(tag);
-        addCommentTags(element, tag, description, false, false, false, htmltree);
+        addCommentTags(element, description, false, false, false, htmltree);
     }
 
     /**
@@ -1248,22 +1248,6 @@ public class HtmlDocletWriter {
      * @param htmltree the documentation tree to which the comment tags will be added
      */
     private void addCommentTags(Element element, List<? extends DocTree> tags, boolean depr,
-            boolean first, boolean inSummary, Content htmltree) {
-        addCommentTags(element, null, tags, depr, first, inSummary, htmltree);
-    }
-
-    /**
-     * Adds the comment tags.
-     *
-     * @param element for which the comment tags will be generated
-     * @param holderTag the block tag context for the inline tags
-     * @param tags the first sentence tags for the doc
-     * @param depr true if it is deprecated
-     * @param first true if the first sentence tags should be added
-     * @param inSummary true if the comment tags are added into the summary section
-     * @param htmltree the documentation tree to which the comment tags will be added
-     */
-    private void addCommentTags(Element element, DocTree holderTag, List<? extends DocTree> tags, boolean depr,
             boolean first, boolean inSummary, Content htmltree) {
         if (options.noComment()) {
             return;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
@@ -38,7 +38,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlId;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
-import jdk.javadoc.internal.doclets.formats.html.markup.RawHtml;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 
@@ -136,25 +135,22 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
     /**
      * Add the summary link for the member.
      *
-     * @param mw the writer for the member being documented
      * @param member the member to be documented
      * @param contentTree the content tree to which the link will be added
      */
-    public void addSummaryLinkComment(AbstractMemberWriter mw, Element member, Content contentTree) {
+    public void addSummaryLinkComment(Element member, Content contentTree) {
         List<? extends DocTree> tags = utils.getFirstSentenceTrees(member);
-        addSummaryLinkComment(mw, member, tags, contentTree);
+        addSummaryLinkComment(member, tags, contentTree);
     }
 
     /**
      * Add the summary link comment.
      *
-     * @param mw the writer for the member being documented
      * @param member the member being documented
      * @param firstSentenceTags the first sentence tags for the member to be documented
      * @param tdSummary the content tree to which the comment will be added
      */
-    public void addSummaryLinkComment(AbstractMemberWriter mw,
-            Element member, List<? extends DocTree> firstSentenceTags, Content tdSummary) {
+    public void addSummaryLinkComment(Element member, List<? extends DocTree> firstSentenceTags, Content tdSummary) {
         addIndexComment(member, firstSentenceTags, tdSummary);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
@@ -97,7 +97,6 @@ public class InheritDocTaglet extends BaseTaglet {
             if (!inheritedDoc.inlineTags.isEmpty()) {
                 replacement = writer.commentTagsToOutput(inheritedDoc.holder, inheritedDoc.holderTag,
                     inheritedDoc.inlineTags, isFirstSentence);
-                ch.setOverrideElement(inheritedDoc.holder);
             }
 
         } else {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -206,9 +206,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                     String lname = kind != ParamKind.TYPE_PARAMETER
                             ? utils.getSimpleName(e)
                             : utils.getTypeName(e.asType(), false);
-                    CommentHelper ch = utils.getCommentHelper(holder);
-                    ch.setOverrideElement(inheritedDoc.holder);
-                    Content content = processParamTag(holder, kind, writer,
+                    Content content = processParamTag(inheritedDoc.holder, kind, writer,
                             (ParamTree) inheritedDoc.holderTag,
                             lname,
                             alreadyDocumented.isEmpty());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
@@ -121,9 +121,7 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
         Input input = new DocFinder.Input(utils, holder, this);
         DocFinder.Output inheritedDoc = DocFinder.search(writer.configuration(), input);
         if (inheritedDoc.holderTag != null) {
-            CommentHelper ch = utils.getCommentHelper(input.element);
-            ch.setOverrideElement(inheritedDoc.holder);
-            return writer.returnTagOutput(holder, (ReturnTree) inheritedDoc.holderTag, false);
+            return writer.returnTagOutput(inheritedDoc.holder, (ReturnTree) inheritedDoc.holderTag, false);
         }
         return null;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -165,26 +165,8 @@ public class CommentHelper {
             }
             return configuration.docEnv.getTypeUtils().asElement(symbol);
         }
-        // case A: the element contains no comments associated and
-        // the comments need to be copied from ancestor
-        // case B: the element has @inheritDoc, then the ancestral comment
-        // as appropriate has to be copied over.
-
-        // Case A.
-        if (dcTree == null && overriddenElement != null) {
-            CommentHelper ovch = utils.getCommentHelper(overriddenElement);
-            return ovch.getElement(rtree);
-        }
-        if (dcTree == null) {
-            return null;
-        }
-        DocTreePath docTreePath = DocTreePath.getPath(path, dcTree, rtree);
+        DocTreePath docTreePath = getDocTreePath(rtree);
         if (docTreePath == null) {
-            // Case B.
-            if (overriddenElement != null) {
-                CommentHelper ovch = utils.getCommentHelper(overriddenElement);
-                return ovch.getElement(rtree);
-            }
             return null;
         }
         DocTrees doctrees = configuration.docEnv.getDocTrees();
@@ -192,10 +174,7 @@ public class CommentHelper {
     }
 
     public TypeMirror getType(ReferenceTree rtree) {
-        // Workaround for JDK-8269706
-        if (path == null || dcTree == null || rtree == null)
-            return null;
-        DocTreePath docTreePath = DocTreePath.getPath(path, dcTree, rtree);
+        DocTreePath docTreePath = getDocTreePath(rtree);
         if (docTreePath != null) {
             DocTrees doctrees = configuration.docEnv.getDocTrees();
             return doctrees.getType(docTreePath);
@@ -700,8 +679,12 @@ public class CommentHelper {
     }
 
     public DocTreePath getDocTreePath(DocTree dtree) {
-        if (path == null || dcTree == null || dtree == null)
+        if (dcTree == null && overriddenElement != null) {
+            // This is an inherited comment, return path from ancestor.
+            return configuration.utils.getCommentHelper(overriddenElement).getDocTreePath(dtree);
+        } else if (path == null || dcTree == null || dtree == null) {
             return null;
+        }
         return DocTreePath.getPath(path, dcTree, dtree);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -685,7 +685,12 @@ public class CommentHelper {
         } else if (path == null || dcTree == null || dtree == null) {
             return null;
         }
-        return DocTreePath.getPath(path, dcTree, dtree);
+        DocTreePath dtPath = DocTreePath.getPath(path, dcTree, dtree);
+        if (dtPath == null && overriddenElement != null) {
+            // The overriding element has a doc tree, but it doesn't contain what we're looking for.
+            return configuration.utils.getCommentHelper(overriddenElement).getDocTreePath(dtree);
+        }
+        return dtPath;
     }
 
     public Element getOverriddenElement() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
@@ -518,6 +518,9 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic position
      */
     private DiagnosticPosition getDiagnosticPosition(DocTreePath path) {
+        if (path == null || path.getTreePath() == null) {
+            return null;
+        }
         DocSourcePositions posns = getSourcePositions();
         CompilationUnitTree compUnit = path.getTreePath().getCompilationUnit();
         int start = (int) posns.getStartPosition(compUnit, path.getDocComment(), path.getLeaf());
@@ -533,6 +536,9 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic position
      */
     private DiagnosticPosition getDiagnosticPosition(Element element) {
+        if (element == null) {
+            return null;
+        }
         ToolEnvironment toolEnv = getToolEnv();
         DocSourcePositions posns = getSourcePositions();
         TreePath tp = toolEnv.elementToTreePath.get(element);
@@ -615,6 +621,9 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic source
      */
     private DiagnosticSource getDiagnosticSource(DocTreePath path) {
+        if (path == null || path.getTreePath() == null) {
+            return null;
+        }
         return getDiagnosticSource(path.getTreePath().getCompilationUnit().getSourceFile());
     }
 
@@ -626,6 +635,9 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic source
      */
     private DiagnosticSource getDiagnosticSource(Element element) {
+        if (element == null) {
+            return null;
+        }
         TreePath tp = getToolEnv().elementToTreePath.get(element);
         return tp == null ? DiagnosticSource.NO_SOURCE
                 : getDiagnosticSource(tp.getCompilationUnit().getSourceFile());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
@@ -518,9 +518,6 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic position
      */
     private DiagnosticPosition getDiagnosticPosition(DocTreePath path) {
-        if (path == null || path.getTreePath() == null) {
-            return null;
-        }
         DocSourcePositions posns = getSourcePositions();
         CompilationUnitTree compUnit = path.getTreePath().getCompilationUnit();
         int start = (int) posns.getStartPosition(compUnit, path.getDocComment(), path.getLeaf());
@@ -536,9 +533,6 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic position
      */
     private DiagnosticPosition getDiagnosticPosition(Element element) {
-        if (element == null) {
-            return null;
-        }
         ToolEnvironment toolEnv = getToolEnv();
         DocSourcePositions posns = getSourcePositions();
         TreePath tp = toolEnv.elementToTreePath.get(element);
@@ -621,9 +615,6 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic source
      */
     private DiagnosticSource getDiagnosticSource(DocTreePath path) {
-        if (path == null || path.getTreePath() == null) {
-            return null;
-        }
         return getDiagnosticSource(path.getTreePath().getCompilationUnit().getSourceFile());
     }
 
@@ -635,9 +626,6 @@ public class JavadocLog extends Log implements Reporter {
      * @return the diagnostic source
      */
     private DiagnosticSource getDiagnosticSource(Element element) {
-        if (element == null) {
-            return null;
-        }
         TreePath tp = getToolEnv().elementToTreePath.get(element);
         return tp == null ? DiagnosticSource.NO_SOURCE
                 : getDiagnosticSource(tp.getCompilationUnit().getSourceFile());

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8269722
+ * @bug 8269722 8270866
  * @summary NPE in HtmlDocletWriter, reporting errors on inherited tags
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -90,6 +90,35 @@ public class TestInherited extends JavadocTester {
         javadoc("-d", base.resolve("out").toString(),
                 "-Xdoclint:-missing",
                 src.resolve("BadReturn.java").toString());
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void testBadInheritedReference(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                public class BadReference {
+                    public interface Intf {
+                        /**
+                         * {@link NonExistingClass}
+                         */
+                        public void m();
+                    }
+
+                    public static class Impl1 implements Intf {
+                        public void m() { }
+                    }
+                    
+                    public static class Impl2 implements Intf {
+                        /** {@inheritDoc} */
+                        public void m() { }
+                    }
+                }
+                """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-Xdoclint:-reference",
+                src.resolve("BadReference.java").toString());
         checkExit(Exit.OK);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -110,7 +110,17 @@ public class TestInherited extends JavadocTester {
                     }
 
                     public static class Impl2 implements Intf {
-                        /** {@inheritDoc} */
+                        /**
+                         * {@inheritDoc}
+                         */
+                        public void m() { }
+                    }
+
+                    // subclass has doc comment but inherits main description
+                    public static class Impl3 implements Intf {
+                        /**
+                         * @since 1
+                         */
                         public void m() { }
                     }
                 }

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -67,6 +67,14 @@ public class TestInherited extends JavadocTester {
                 "-Xdoclint:-missing", "-XDdoe",
                 src.resolve("BadParam.java").toString());
         checkExit(Exit.OK);
+        checkOutput("BadParam.Base.html", true, """
+                <dt>Parameters:</dt>
+                <dd><code>i</code> - a &lt; b</dd>
+                """);
+        checkOutput("BadParam.Sub.html", true, """
+                <dt>Parameters:</dt>
+                <dd><code>i</code> - a &lt; b</dd>
+                """);
     }
 
     @Test
@@ -91,6 +99,14 @@ public class TestInherited extends JavadocTester {
                 "-Xdoclint:-missing",
                 src.resolve("BadReturn.java").toString());
         checkExit(Exit.OK);
+        checkOutput("BadReturn.Base.html", true, """
+                <dt>Returns:</dt>
+                <dd>a &lt; b</dd>
+                """);
+        checkOutput("BadReturn.Sub.html", true, """
+                <dt>Returns:</dt>
+                <dd>a &lt; b</dd>
+                """);
     }
 
     @Test
@@ -130,5 +146,17 @@ public class TestInherited extends JavadocTester {
                 "-Xdoclint:-reference",
                 src.resolve("BadReference.java").toString());
         checkExit(Exit.OK);
+        checkOutput("BadReference.Intf.html", true, """
+                <div class="block"><code>NonExistingClass</code></div>
+                """);
+        checkOutput("BadReference.Impl1.html", true, """
+                <div class="block"><code>NonExistingClass</code></div>
+                """);
+        checkOutput("BadReference.Impl2.html", true, """
+                <div class="block"><code>NonExistingClass</code></div>
+                """);
+        checkOutput("BadReference.Impl3.html", true, """
+                <div class="block"><code>NonExistingClass</code></div>
+                """);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -108,7 +108,7 @@ public class TestInherited extends JavadocTester {
                     public static class Impl1 implements Intf {
                         public void m() { }
                     }
-                    
+
                     public static class Impl2 implements Intf {
                         /** {@inheritDoc} */
                         public void m() { }


### PR DESCRIPTION
This change fixes a NPE in `JavadocLog` when the `DocTreePath` for an inherited doc comment can't be retrieved. 

The most important change is to fix the `overriddenElement` feature in `CommentHelper`. The purpose of this feature is to enable lookup of the `DocTreePath` or `Element` if the comment was inherited from an overridden member, but it was not implemented and used correctly. With this change, the feature is implemented in `CommentHelper.getDocTreePath(DocTree)` and that method is used whenever the `DocTreePath` is needed instead of duplicating the functionality elsewhere.

The `CommentHelper.setOverrideElement(Element)` method was previously used in four places:

 - In `InheritDocTaglet.java` when generating a piece of inherited documentation
 - In `ReturnTaglet` when generating inherited return value documentation
 - In `ParamTaglet` when generating inherited documentation for a parameter
 - In `MemberSummaryBuilder` when generating inherited summary documentation for an executable member
 
The first three usages have been removed with this change because they were not necessary. We can simply use the overridden member owning the comment instead of the overriding one to generate the output. In `InheritDocTaglet` we already did that, in `ReturnTaglet` and `ParamTaglet` I changed the first argument to the doc-generating method from `holder` to `inheritedDoc.holder`. (Note that in `ParamTaglet` the name of the parameter which can change in the overriding member is passed as separate argument.)

The remaining use of `CommentHelper.setOverrideElement(Element)` in `MemberSummaryBuilder` was a bit more difficult, since the invoked method `MemberSummaryWriter.addMemberSummary` generates not just the doc comment, but the whole summary line including the member signature. I tried adding the `CommentHelper` or `Element` owning the comment as an additional parameter, but there is pretty long line of methods that must carry the extra parameter around (as can be seen in the stack trace in the JBS issue). In the end I decided to keep the current mechanism to register the overridden holder element with the comment helper.

One thing I am unsure about is whether it is possible for the `CommentHelper` we register the overridden element on in `MemberSummaryBuilder.buildSummary` to be garbage collected under extreme memory pressure before it is retrieved and used again down the call graph. The local reference we use to register the comment holder is no longer reachable at that time and it is referenced by a `SoftReference` in `CommentHelperCache`. This is probably more of a theoretical issue, and it has existed before, but I thought I should mention it.

Although it should no longer be required, I added back the null checks in the methods to retrieve the `DiagnosticSource` and `DiagnosticPosition` instances in `JavadocLog`. These null checks have been there in the method's precursors in the `Messager` class and were dropped in JDK-8267126. As far as I can tell, all the reporting functionality in `JavadocLog` accepts null values for source and position, so this seemed like the right thing to do.

Finally, as a byproduct of my attempt of adding a new parameter I dropped some unused parameters in various writer classes. Since this is just cleanup I can undo these changes to keep it as small as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270866](https://bugs.openjdk.java.net/browse/JDK-8270866): NPE in DocTreePath.getTreePath()


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/264/head:pull/264` \
`$ git checkout pull/264`

Update a local copy of the PR: \
`$ git checkout pull/264` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 264`

View PR using the GUI difftool: \
`$ git pr show -t 264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/264.diff">https://git.openjdk.java.net/jdk17/pull/264.diff</a>

</details>
