### PR TITLE
8271093: remove deadcode from runtime/Thread/TestThreadDumpSMRInfo.java test

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpSMRInfo.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpSMRInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,10 +84,5 @@ public class TestThreadDumpSMRInfo {
         System.out.println("INFO: Found: '" + HEADER_STR + "' in jstack output.");
 
         System.out.println("Test PASSED.");
-    }
-
-    static void usage() {
-        System.err.println("Usage: java TestThreadDumpSMRInfo [-v]");
-        System.exit(1);
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this trivial test-only clean-up?
from JBS:
> TestThreadDumpSMRInfo::usage isn't used by anyone and should be removed


PS alternatively, `TestThreadDumpSMRInfo::usage` can be called in an else branch at L70, but I don't see much point in that

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271093](https://bugs.openjdk.java.net/browse/JDK-8271093): remove deadcode from runtime/Thread/TestThreadDumpSMRInfo.java test


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/265.diff">https://git.openjdk.java.net/jdk17/pull/265.diff</a>

</details>
