### PR TITLE
8271094: runtime/duplAttributes/DuplAttributesTest.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/duplAttributes/DuplAttributesTest.java
+++ b/test/hotspot/jtreg/runtime/duplAttributes/DuplAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class DuplAttributesTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(test);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("java.lang.ClassFormatError: Multiple " + result);
+        output.shouldNotHaveExitValue(0);
     }
 
     public static void main(String args[]) throws Throwable {


### PR DESCRIPTION
Hi all,

could you please review this trivial test-only patch that adds a check of the exit code to `runtime/duplAttributes/DuplAttributesTest.java` test?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271094](https://bugs.openjdk.java.net/browse/JDK-8271094): runtime/duplAttributes/DuplAttributesTest.java doesn't check exit code


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/266.diff">https://git.openjdk.java.net/jdk17/pull/266.diff</a>

</details>
