### PR TITLE
8271158: runtime/handshake/HandshakeTimeoutTest.java test doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
@@ -57,6 +57,7 @@ public class HandshakeTimeoutTest {
                     "HandshakeTimeoutTest$Test");
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldNotHaveExitValue(0);
         output.reportDiagnosticSummary();
         // In rare cases the target wakes up and performs the handshake at the same time as we timeout.
         // Therefore it's not certain the timeout will find any thread.


### PR DESCRIPTION
Hi all,

could you please review this one-liner that adds an exit code check to `runtime/handshake/HandshakeTimeoutTest.java` test?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271158](https://bugs.openjdk.java.net/browse/JDK-8271158): runtime/handshake/HandshakeTimeoutTest.java test doesn't check exit code


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/270.diff">https://git.openjdk.java.net/jdk17/pull/270.diff</a>

</details>
