### PR TITLE
8271155: Wrong path separator in env variable

### DIFF
--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -113,7 +113,7 @@ Jvm* AppLauncher::createJvmLauncher() const {
     }
 
     SysInfo::setEnvVariable(libEnvVarName, SysInfo::getEnvVariable(
-            std::nothrow, libEnvVarName) + _T(";") + appDirPath);
+            std::nothrow, libEnvVarName) + FileUtils::pathSeparator + appDirPath);
 
     std::unique_ptr<Jvm> jvm(new Jvm());
 


### PR DESCRIPTION
Replace `";"` with `FileUtils::pathSeparator` in the expression adding 'app' dir to env variable in jpackage app launcher.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271155](https://bugs.openjdk.java.net/browse/JDK-8271155): Wrong path separator in env variable


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/271.diff">https://git.openjdk.java.net/jdk17/pull/271.diff</a>

</details>
