### PR TITLE
8015886: java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java sometimes failed on ubuntu

### DIFF
--- a/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
+++ b/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
+++ b/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
@@ -43,7 +43,11 @@ public class DeiconifiedFrameLoosesFocus {
     public static void main(String[] args) {
         DeiconifiedFrameLoosesFocus app = new DeiconifiedFrameLoosesFocus();
         app.init();
-        app.start();
+        try {
+            app.start();
+        } finally {
+            frame.dispose();
+        }
     }
 
     public void init() {

--- a/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
+++ b/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
@@ -79,10 +79,12 @@ public class DeiconifiedFrameLoosesFocus {
         frame.setExtendedState(Frame.ICONIFIED);
 
         Util.waitForIdle(robot);
+        robot.delay(200);
 
         frame.setExtendedState(Frame.NORMAL);
 
         Util.waitForIdle(robot);
+        robot.delay(200);
 
         if (!frame.isFocused()) {
             throw new TestFailedException("the Frame didn't regain focus after restoring!");

--- a/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
+++ b/test/jdk/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java
@@ -31,7 +31,9 @@
   @run        main DeiconifiedFrameLoosesFocus
 */
 
-import java.awt.*;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.Toolkit;
 import test.java.awt.regtesthelpers.Util;
 
 public class DeiconifiedFrameLoosesFocus {
@@ -61,6 +63,7 @@ public class DeiconifiedFrameLoosesFocus {
         frame.setVisible(true);
 
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         if (!frame.isFocused()) {
             Util.clickOnTitle(frame, robot);
@@ -79,12 +82,12 @@ public class DeiconifiedFrameLoosesFocus {
         frame.setExtendedState(Frame.ICONIFIED);
 
         Util.waitForIdle(robot);
-        robot.delay(200);
+        robot.delay(500);
 
         frame.setExtendedState(Frame.NORMAL);
 
         Util.waitForIdle(robot);
-        robot.delay(200);
+        robot.delay(500);
 
         if (!frame.isFocused()) {
             throw new TestFailedException("the Frame didn't regain focus after restoring!");


### PR DESCRIPTION
This test can fail pretty consistently on some slow systems. Increased delay fixes the issue. 
We do have similar fix in #260

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8015886](https://bugs.openjdk.java.net/browse/JDK-8015886): java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.java sometimes failed on ubuntu


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 10ca677e027f3bfd2853240742b57c0774805eb6
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/272/head:pull/272` \
`$ git checkout pull/272`

Update a local copy of the PR: \
`$ git checkout pull/272` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 272`

View PR using the GUI difftool: \
`$ git pr show -t 272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/272.diff">https://git.openjdk.java.net/jdk17/pull/272.diff</a>

</details>
