### PR TITLE
8271160: runtime/jni/checked/TestCheckedJniExceptionCheck.java doesn't set -Djava.library.path

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -189,6 +189,9 @@ public class TestCheckedJniExceptionCheck {
                 expectedWarnings = 0;
             }
         }
+        if (!testStartLine) {
+            throw new RuntimeException("Missing test start line after " + lineNo + " lines");
+        }
         /*
         System.out.println("Output looks good...");
         oa.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,8 @@ public class TestCheckedJniExceptionCheck {
 
         // launch and check output
         checkOuputForCorrectWarnings(ProcessTools.executeTestJvm("-Xcheck:jni",
-                                                                  "TestCheckedJniExceptionCheck"));
+                                                                 "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                                                 "TestCheckedJniExceptionCheck"));
     }
 
 }

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -175,12 +175,10 @@ public class TestCheckedJniExceptionCheck {
                     oa.reportDiagnosticSummary();
                     throw new RuntimeException("Unexpected warning at line " + lineNo);
                 }
-            }
-            else if (line.startsWith(EXPECT_WARNING_START)) {
+            } else if (line.startsWith(EXPECT_WARNING_START)) {
                 String countStr = line.substring(EXPECT_WARNING_START.length() + 1);
                 expectedWarnings = Integer.parseInt(countStr);
-            }
-            else if (line.startsWith(EXPECT_WARNING_END)) {
+            } else if (line.startsWith(EXPECT_WARNING_END)) {
                 if (warningCount != expectedWarnings) {
                     oa.reportDiagnosticSummary();
                     throw new RuntimeException("Missing warning at line " + lineNo);

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -155,6 +155,7 @@ public class TestCheckedJniExceptionCheck {
 
     // Check warnings appear where they should, with start/end statements in output...
     static void checkOuputForCorrectWarnings(OutputAnalyzer oa) throws RuntimeException {
+        oa.shouldHaveExitValue(0);
         List<String> lines = oa.asLines();
         int expectedWarnings = 0;
         int warningCount = 0;

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -30,6 +30,7 @@
  */
 
 import java.util.List;
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 


### PR DESCRIPTION
Hi all,

could you please review this small patch that sets `-Djava.library.path` to ` test.nativepath` for `TestCheckedJniExceptionCheck`'s child JVM so it will be able to locate the library?

from JBS:
> TestCheckedJniExceptionCheck spawns a child JVM that uses a test native library, TestCheckedJniExceptionCheck, but it doesn't add/set test.nativepath value to -Djava.library.path, so the child JVM can't find the library and fails. 
>
> this issue hasn't been noticed early b/c TestCheckedJniExceptionCheck doesn't check the exit code of the child JVM.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271160](https://bugs.openjdk.java.net/browse/JDK-8271160): runtime/jni/checked/TestCheckedJniExceptionCheck.java doesn't set -Djava.library.path


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to ff88410357805d16bd713ecadd3154ebb3342e21
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/273/head:pull/273` \
`$ git checkout pull/273`

Update a local copy of the PR: \
`$ git checkout pull/273` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 273`

View PR using the GUI difftool: \
`$ git pr show -t 273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/273.diff">https://git.openjdk.java.net/jdk17/pull/273.diff</a>

</details>
