### PR TITLE
8271162: runtime/StackTrace/LargeClassTest.java can be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/StackTrace/LargeClassTest.java
+++ b/test/hotspot/jtreg/runtime/StackTrace/LargeClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile LargeClassTest.java
- * @run main LargeClassTest
+ * @run driver LargeClassTest
  */
 
 import java.io.File;


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that changes `LargeClassTest` to be executed in a driver mode and removes the redundant, due to an implicit `@build` action associated with `@run`, `@compile` action?

testing: `runtime/StackTrace/LargeClassTest.java` on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271162](https://bugs.openjdk.java.net/browse/JDK-8271162): runtime/StackTrace/LargeClassTest.java can be run in driver mode


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/274/head:pull/274` \
`$ git checkout pull/274`

Update a local copy of the PR: \
`$ git checkout pull/274` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 274`

View PR using the GUI difftool: \
`$ git pr show -t 274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/274.diff">https://git.openjdk.java.net/jdk17/pull/274.diff</a>

</details>
