### PR TITLE
8271169: runtime/Safepoint/TestAbortVMOnSafepointTimeout.java can be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -31,9 +31,9 @@ import sun.hotspot.WhiteBox;
  * @summary Check if VM can kill thread which doesn't reach safepoint.
  * @bug 8219584 8227528
  * @library /testlibrary /test/lib
- * @build TestAbortVMOnSafepointTimeout
+ * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestAbortVMOnSafepointTimeout
+ * @run driver TestAbortVMOnSafepointTimeout
  */
 
 public class TestAbortVMOnSafepointTimeout {


### PR DESCRIPTION
Hi all,

could you please review this small and trivial test-only patch?
from JBS:
> `runtime/Safepoint/TestAbortVMOnSafepointTimeout.java` uses `main/othervm` so `TestAbortVMOnSafepointTimeout` is run w/ the flags required for WhiteBox API, yet `TestAbortVMOnSafepointTimeout` doesn't use WhiteBox API and can be run in driver mode.

testing: `runtime/Safepoint/TestAbortVMOnSafepointTimeout.java` on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271169](https://bugs.openjdk.java.net/browse/JDK-8271169): runtime/Safepoint/TestAbortVMOnSafepointTimeout.java can be run in driver mode


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/275/head:pull/275` \
`$ git checkout pull/275`

Update a local copy of the PR: \
`$ git checkout pull/275` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 275`

View PR using the GUI difftool: \
`$ git pr show -t 275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/275.diff">https://git.openjdk.java.net/jdk17/pull/275.diff</a>

</details>
