### PR TITLE
8271174: runtime/ClassFile/UnsupportedClassFileVersion.java can be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,7 @@
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
  *          java.management
- * @compile -XDignore.symbol.file UnsupportedClassFileVersion.java
- * @run main UnsupportedClassFileVersion
+ * @run driver UnsupportedClassFileVersion
  */
 
 import java.io.File;


### PR DESCRIPTION
Hi all,

could you please review this trivial patch that switches execution mode in `runtime/ClassFile/UnsupportedClassFileVersion.java` test to `driver`?

testing: `runtime/ClassFile/UnsupportedClassFileVersion.java` on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271174](https://bugs.openjdk.java.net/browse/JDK-8271174): runtime/ClassFile/UnsupportedClassFileVersion.java can be run in driver mode


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/276/head:pull/276` \
`$ git checkout pull/276`

Update a local copy of the PR: \
`$ git checkout pull/276` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 276`

View PR using the GUI difftool: \
`$ git pr show -t 276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/276.diff">https://git.openjdk.java.net/jdk17/pull/276.diff</a>

</details>
