### PR TITLE
8271173: serviceability/jvmti/GetObjectSizeClass.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
@@ -54,6 +54,7 @@ public class GetObjectSizeClass {
 
         ProcessBuilder pt = ProcessTools.createTestJvm("-javaagent:agent.jar",  "GetObjectSizeClassAgent");
         OutputAnalyzer output = new OutputAnalyzer(pt.start());
+        output.shouldHaveExitValue(0);
 
         output.stdoutShouldContain("GetObjectSizeClass passed");
     }


### PR DESCRIPTION
Hi all,

could you please review the patch that adds an exit-code check to `serviceability/jvmti/GetObjectSizeClass.java` test?

from JBS:
> `serviceability/jvmti/GetObjectSizeClass.java` test spawns a new JVM but doesn't check its exit code which might lead to both type-I and type-II errors

testing:  `serviceability/jvmti/GetObjectSizeClass.java`  on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271173](https://bugs.openjdk.java.net/browse/JDK-8271173): serviceability/jvmti/GetObjectSizeClass.java doesn't check exit code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/277/head:pull/277` \
`$ git checkout pull/277`

Update a local copy of the PR: \
`$ git checkout pull/277` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 277`

View PR using the GUI difftool: \
`$ git pr show -t 277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/277.diff">https://git.openjdk.java.net/jdk17/pull/277.diff</a>

</details>
