### PR TITLE
8271189: runtime/handshake/HandshakeTimeoutTest.java can be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
@@ -36,7 +36,7 @@ import sun.hotspot.WhiteBox;
  * @library /testlibrary /test/lib
  * @build HandshakeTimeoutTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main HandshakeTimeoutTest
+ * @run driver HandshakeTimeoutTest
  */
 
 public class HandshakeTimeoutTest {


### PR DESCRIPTION
Hi all,

could you please review this tiny patch?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271189](https://bugs.openjdk.java.net/browse/JDK-8271189): runtime/handshake/HandshakeTimeoutTest.java can be run in driver mode


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/278.diff">https://git.openjdk.java.net/jdk17/pull/278.diff</a>

</details>
