### PR TITLE
8271222: two runtime/Monitor tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
@@ -93,6 +93,7 @@ public class MonitorUsedDeflationThresholdTest {
                 "MonitorUsedDeflationThresholdTest", "33");
 
             OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
+            output_detail.shouldHaveExitValue(0);
 
             // This mesg means:
             // - AvgMonitorsPerThreadEstimate == 1 reduced in_use_list_ceiling

--- a/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
@@ -95,6 +95,7 @@ public class SyncOnValueBasedClassTest {
         for (int i = 0; i < logTests.length; i++) {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(logTests[i]);
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            output.shouldHaveExitValue(0);
             checkOutput(output);
         }
     }


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch?

testing: `runtime/Monitor` tests on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271222](https://bugs.openjdk.java.net/browse/JDK-8271222): two runtime/Monitor tests don't check exit code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/280/head:pull/280` \
`$ git checkout pull/280`

Update a local copy of the PR: \
`$ git checkout pull/280` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 280`

View PR using the GUI difftool: \
`$ git pr show -t 280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/280.diff">https://git.openjdk.java.net/jdk17/pull/280.diff</a>

</details>
