### PR TITLE
8271223: two runtime/ClassFile tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
@@ -74,6 +74,7 @@ public class JsrRewriting {
             className);
 
         output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         String[] expectedMsgs = {
             "java.lang.LinkageError",
             "java.lang.NoSuchMethodError",

--- a/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
@@ -73,6 +73,7 @@ public class OomWhileParsingRepeatedJsr {
             className );
 
         output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("Cannot reserve enough memory");
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch?

testing: `runtime/ClassFile` tests on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271223](https://bugs.openjdk.java.net/browse/JDK-8271223): two runtime/ClassFile tests don't check exit code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/281.diff">https://git.openjdk.java.net/jdk17/pull/281.diff</a>

</details>
