### PR TITLE
8271175: runtime/jni/FindClassUtf8/FindClassUtf8.java doesn't have to be run in othervm

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/FindClassUtf8/FindClassUtf8.java
+++ b/test/hotspot/jtreg/runtime/jni/FindClassUtf8/FindClassUtf8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,10 @@
  * @bug 8166358
  * @summary verify that -Xcheck:jni finds a bad utf8 name for class name.
  * @library /test/lib
- * @run main/native/othervm FindClassUtf8 test
+ * @run main/native FindClassUtf8 test
  */
 
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -42,7 +43,10 @@ public final class FindClassUtf8 {
     public static void main(String... args) throws Exception {
         if (args.length == 1) {
             // run java -Xcheck:jni FindClassUtf8 and check that the -Xcheck:jni message comes out.
-            ProcessTools.executeTestJvm("-Xcheck:jni", "-XX:-CreateCoredumpOnCrash", "FindClassUtf8")
+            ProcessTools.executeTestJvm("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                        "-Xcheck:jni",
+                                        "-XX:-CreateCoredumpOnCrash",
+                                        "FindClassUtf8")
                       .shouldContain("JNI class name is not a valid UTF8 string")
                       .shouldNotHaveExitValue(0);  // you get a core dump from -Xcheck:jni failures
         } else {


### PR DESCRIPTION
Hi all,

could you please review this small patch?

testing: `runtime/jni/FindClassUtf8/FindClassUtf8.java` on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271175](https://bugs.openjdk.java.net/browse/JDK-8271175): runtime/jni/FindClassUtf8/FindClassUtf8.java doesn't have to be run in othervm


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/282/head:pull/282` \
`$ git checkout pull/282`

Update a local copy of the PR: \
`$ git checkout pull/282` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 282`

View PR using the GUI difftool: \
`$ git pr show -t 282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/282.diff">https://git.openjdk.java.net/jdk17/pull/282.diff</a>

</details>
