### PR TITLE
8271251: JavaThread::java_suspend() fails with "fatal error: Illegal threadstate encountered: 6"

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -612,6 +612,7 @@ void HandshakeState::do_self_suspend() {
   assert(Thread::current() == _handshakee, "should call from _handshakee");
   assert(_lock.owned_by_self(), "Lock must be held");
   assert(!_handshakee->has_last_Java_frame() || _handshakee->frame_anchor()->walkable(), "should have walkable stack");
+  assert(_handshakee->thread_state() == _thread_blocked, "Caller should have transitioned to _thread_blocked");
 
   log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
   while (is_suspended()) {

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -614,8 +614,8 @@ void HandshakeState::do_self_suspend() {
   assert(!_handshakee->has_last_Java_frame() || _handshakee->frame_anchor()->walkable(), "should have walkable stack");
   assert(_handshakee->thread_state() == _thread_blocked, "Caller should have transitioned to _thread_blocked");
 
-  log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
   while (is_suspended()) {
+    log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
     _lock.wait_without_safepoint_check();
   }
   log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " resumed", p2i(_handshakee));

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -612,14 +612,11 @@ void HandshakeState::do_self_suspend() {
   assert(Thread::current() == _handshakee, "should call from _handshakee");
   assert(_lock.owned_by_self(), "Lock must be held");
   assert(!_handshakee->has_last_Java_frame() || _handshakee->frame_anchor()->walkable(), "should have walkable stack");
-  JavaThreadState jts = _handshakee->thread_state();
+
+  log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
   while (is_suspended()) {
-    _handshakee->set_thread_state(_thread_blocked);
-    log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
     _lock.wait_without_safepoint_check();
   }
-  _handshakee->set_thread_state(jts);
-  set_async_suspend_handshake(false);
   log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " resumed", p2i(_handshakee));
 }
 
@@ -631,7 +628,12 @@ class ThreadSelfSuspensionHandshake : public AsyncHandshakeClosure {
   void do_thread(Thread* thr) {
     JavaThread* current = thr->as_Java_thread();
     assert(current == Thread::current(), "Must be self executed.");
+    JavaThreadState jts = current->thread_state();
+
+    current->set_thread_state(_thread_blocked);
     current->handshake_state()->do_self_suspend();
+    current->set_thread_state(jts);
+    current->handshake_state()->set_async_suspend_handshake(false);
   }
   virtual bool is_suspend() { return true; }
 };
@@ -681,15 +683,19 @@ public:
 
 bool HandshakeState::suspend() {
   JavaThread* self = JavaThread::current();
-  SuspendThreadHandshake st;
-  Handshake::execute(&st, _handshakee);
   if (_handshakee == self) {
-    // If target is the current thread we need to call this to do the
-    // actual suspend since Handshake::execute() above only installed
-    // the asynchronous handshake.
-    SafepointMechanism::process_if_requested(self);
+    // If target is the current thread we can bypass the handshake machinery
+    // and just suspend directly
+    ThreadBlockInVM tbivm(self);
+    MutexLocker ml(&_lock, Mutex::_no_safepoint_check_flag);
+    set_suspended(true);
+    do_self_suspend();
+    return true;
+  } else {
+    SuspendThreadHandshake st;
+    Handshake::execute(&st, _handshakee);
+    return st.did_suspend();
   }
-  return st.did_suspend();
 }
 
 bool HandshakeState::resume() {


### PR DESCRIPTION
Hi,

Please review this small patch. When self-suspending, a JavaThread might reach SafepointSynchronize::block() with a state of _thread_in_vm which is not listed as a valid state for safepoint polling. There are a couple of simple ways to fix this. As suggested by @dholmes-ora  we can avoid the handshake machinery altogether and directly self-suspend. Since this issue is intermittent and in tier7 which I didn't run as many times as other lower tiers it escaped my testing of 8270085.

Testing in mach5 tiers1-7. I also reproduced the test failures locally and verified that now both hs202t002.java and ThreadSuspendSelf.java are passing. 

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271251](https://bugs.openjdk.java.net/browse/JDK-8271251): JavaThread::java_suspend() fails with "fatal error: Illegal threadstate encountered: 6"


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/283.diff">https://git.openjdk.java.net/jdk17/pull/283.diff</a>

</details>
