### PR TITLE
8271350: runtime/Safepoint tests use OutputAnalyzer::shouldMatch instead of shouldContaint

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -74,7 +74,7 @@ public class TestAbortOnVMOperationTimeout {
         if (shouldPass) {
             output.shouldHaveExitValue(0);
         } else {
-            output.shouldMatch("VM operation took too long");
+            output.shouldContain("VM operation took too long");
             output.shouldNotHaveExitValue(0);
         }
     }

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -55,13 +55,13 @@ public class TestAbortVMOnSafepointTimeout {
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldMatch("Timed out while spinning to reach a safepoint.");
+        output.shouldContain("Timed out while spinning to reach a safepoint.");
         if (Platform.isWindows()) {
-            output.shouldMatch("Safepoint sync time longer than");
+            output.shouldContain("Safepoint sync time longer than");
         } else {
-            output.shouldMatch("SIGILL");
+            output.shouldContain("SIGILL");
             if (Platform.isLinux()) {
-                output.shouldMatch("(sent by kill)");
+                output.shouldContain("(sent by kill)");
             }
         }
         output.shouldNotHaveExitValue(0);


### PR DESCRIPTION
Hi all,

could you please review this small patch?

from JBS:
> `runtime/Safepoint/TestAbortVMOnSafepointTimeout.java` and `TestAbortOnVMOperationTimeout.java` tests use `j.t.l.p.OutputAnalyzer::shouldMatch` method, which accepts a regular expression, yet pass a fixed string as an argument.

testing: ``runtime/Safepoint/` on `{windows,linux,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271350](https://bugs.openjdk.java.net/browse/JDK-8271350): runtime/Safepoint tests use OutputAnalyzer::shouldMatch instead of shouldContaint


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/285/head:pull/285` \
`$ git checkout pull/285`

Update a local copy of the PR: \
`$ git checkout pull/285` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 285`

View PR using the GUI difftool: \
`$ git pr show -t 285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/285.diff">https://git.openjdk.java.net/jdk17/pull/285.diff</a>

</details>
