### PR TITLE
8271272: C2: assert(!had_error) failed: bad dominance

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2045,7 +2045,7 @@ Node* CountedLoopNode::match_incr_with_optional_truncation(Node* expr, Node** tr
 }
 
 LoopNode* CountedLoopNode::skip_strip_mined(int expect_skeleton) {
-  if (is_strip_mined() && is_valid_counted_loop(T_INT)) {
+  if (is_strip_mined() && in(EntryControl) != NULL && in(EntryControl)->is_OuterStripMinedLoop()) {
     verify_strip_mined(expect_skeleton);
     return in(EntryControl)->as_Loop();
   }

--- a/test/hotspot/jtreg/compiler/loopopts/TestMainNeverExecuted.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMainNeverExecuted.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8271272
+ * @summary C2: assert(!had_error) failed: bad dominance
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestMainNeverExecuted TestMainNeverExecuted
+ *
+ */
+
+public class TestMainNeverExecuted {
+    public static long y;
+    static int iArrFld[] = new int[400];
+    static long x = 0;
+
+    public static void main(String[] strArr) {
+        for (int i1 = 0; i1 < 100; i1++)
+            vMeth(3, 5);
+    }
+    static void vMeth(int f, int g) {
+        int i3 = 23;
+        int i11 = 2, i12 = 12, i13 = 32901, i14 = 43741;
+        for (i11 = 7; i11 < 325; ++i11) {
+            i13 = 1;
+            while ((i13 += 3) < 5) {
+                iArrFld[i13 - 1] = 906;
+                for (i14 = i13; i14 < 5; i14 += 2) {
+                    y += i14;
+                    i3 += i14;
+                }
+            }
+        }
+        x += i11 + i12 + i13 + i14;
+    }
+}


### PR DESCRIPTION
The test has a counted loop. The type of the iv Phi of the counted loop is set initially to: min+5..7. The loop body contains a ConvI2L of the iv Phi. That value is used as a value to be stored right out of the loop. That ConvI2L captures the type of the iv Phi: minint+5..7. Pre/main/post loops are created. The loop is unrolled once. The ConvI2L is cloned and pushed thru the Add of the iv. The increment of the loop is 2. The new ConvI2L now takes the iv Phi as input and has type: minint+5..5. CCP runs and updates the type of the iv Phi to: int:6..7. That type conflicts with the type of the second ConvI2L. That node is transformed to top which causes the Store to be transformed to top. The Store has a Phi as use. That Phi is transformed to the remaining non top input. That causes the assert failure.

This happens because the main loop body never executes. The entry test would constant fold if it didn't use an Opaque1.

The exit condition of the main loop will next constant fold, the backedge is removed. So the fix for JDK-8269752 should have prevented this issue because once the main loop backedge is removed, the Opaque1 of the entry test should also be removed. But I noticed working on this, that the fix for JDK-8269752 is not sufficient. In the case of JDK-8269752, both the main and post loops loose their backedge but, with the fix, only the Opaque1 for the post loop is removed. That's good enough for JDK-8269752 but not here. The reason the fix for JDK-8269752 doesn't trigger is that the main loop is strip mined. When the main loop looses its backedge, the logic that checks for an Opaque1 in the entry test of the main loop does trigger but because it sees a dying counted loop it doesn't properly step over the outer strip mined loop. The fix I propose changes the logic in CountedLoopNode::skip_strip_mined() so that it works with a dying counted loop node.

Tobias has started testing for this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271272](https://bugs.openjdk.java.net/browse/JDK-8271272): C2: assert(!had_error) failed: bad dominance


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/287/head:pull/287` \
`$ git checkout pull/287`

Update a local copy of the PR: \
`$ git checkout pull/287` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 287`

View PR using the GUI difftool: \
`$ git pr show -t 287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/287.diff">https://git.openjdk.java.net/jdk17/pull/287.diff</a>

</details>
