### PR TITLE
8271402: mark hotspot runtime/os tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
@@ -26,6 +26,7 @@
  * @bug 6515172 8148766
  * @summary Check that availableProcessors reports the correct value when running in a cpuset on linux
  * @requires os.family == "linux"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver AvailableProcessors

--- a/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
+++ b/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
@@ -31,6 +31,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  *   VM was either compiled on a platform which does not define CPU_ALLOC,
  *   or it is executed on a platform that does not support it.
  * @requires os.family == "linux"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestUseCpuAllocPath


### PR DESCRIPTION
Hi all,

could you please review this small patch?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271402](https://bugs.openjdk.java.net/browse/JDK-8271402): mark hotspot runtime/os tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/288.diff">https://git.openjdk.java.net/jdk17/pull/288.diff</a>

</details>
