### PR TITLE
8271489: (doc) Clarify Filter Factory example

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -207,13 +207,13 @@ import static java.lang.System.Logger.Level.ERROR;
  *             // Called from the OIS constructor or perhaps OIS.setObjectInputFilter with no current filter
  *             var filter = filterThreadLocal.get();
  *             if (filter != null) {
- *                 // Prepend a filter to reject all UNDECIDED results
+ *                 // Wrap the filter to reject UNDECIDED results
  *                 filter = ObjectInputFilter.rejectUndecidedClass(filter);
  *             }
  *             if (next != null) {
- *                 // Prepend the next filter to the thread filter, if any
+ *                 // Merge the next filter with the thread filter, if any
  *                 // Initially this is the static JVM-wide filter passed from the OIS constructor
- *                 // Append the filter to reject all UNDECIDED results
+ *                 // Wrap the filter to reject UNDECIDED results
  *                 filter = ObjectInputFilter.merge(next, filter);
  *                 filter = ObjectInputFilter.rejectUndecidedClass(filter);
  *             }
@@ -222,7 +222,7 @@ import static java.lang.System.Logger.Level.ERROR;
  *             // Called from OIS.setObjectInputFilter with a current filter and a stream-specific filter.
  *             // The curr filter already incorporates the thread filter and static JVM-wide filter
  *             // and rejection of undecided classes
- *             // If there is a stream-specific filter prepend it and a filter to recheck for undecided
+ *             // If there is a stream-specific filter wrap it and a filter to recheck for undecided
  *             if (next != null) {
  *                 next = ObjectInputFilter.merge(next, curr);
  *                 next = ObjectInputFilter.rejectUndecidedClass(next);


### PR DESCRIPTION
Improve the clarity of comments in the ObjectInputFilter FilterInThread example.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271489](https://bugs.openjdk.java.net/browse/JDK-8271489): (doc) Clarify Filter Factory example


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/293/head:pull/293` \
`$ git checkout pull/293`

Update a local copy of the PR: \
`$ git checkout pull/293` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 293`

View PR using the GUI difftool: \
`$ git pr show -t 293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/293.diff">https://git.openjdk.java.net/jdk17/pull/293.diff</a>

</details>
