### PR TITLE
8271512: ProblemList serviceability/sa/sadebugd/DebugdConnectTest.java due to 8270326

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,7 +104,7 @@ runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
 # :hotspot_serviceability
 
-serviceability/sa/sadebugd/DebugdConnectTest.java 8239062 macosx-x64
+serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,macosx-aarch64
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8262386 generic-all
 


### PR DESCRIPTION
This test currently doesn't fail because it is skipped, but when JDK-8270199 is fixed (which causes SA tests to be erroneously skipped skipped), we will start to see failures due to JDK-8270326, so DebugdConnectTest.java needs to be problem listed before JDK-8270199 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271512](https://bugs.openjdk.java.net/browse/JDK-8271512): ProblemList serviceability/sa/sadebugd/DebugdConnectTest.java due to 8270326


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/295/head:pull/295` \
`$ git checkout pull/295`

Update a local copy of the PR: \
`$ git checkout pull/295` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 295`

View PR using the GUI difftool: \
`$ git pr show -t 295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/295.diff">https://git.openjdk.java.net/jdk17/pull/295.diff</a>

</details>
