### PR TITLE
8271064: ZGC several jvm08 perf regressions after JDK-8268372

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -212,8 +212,7 @@ ZDriverRequest rule_allocation_rate_dynamic() {
   // Calculate time until GC given the time until OOM and GC duration.
   // We also subtract the sample interval, so that we don't overshoot the
   // target time and end up starting the GC too late in the next interval.
-  const double more_safety_for_fewer_workers = (ConcGCThreads - actual_gc_workers) * sample_interval;
-  const double time_until_gc = time_until_oom - actual_gc_duration - sample_interval - more_safety_for_fewer_workers;
+  const double time_until_gc = time_until_oom - actual_gc_duration - sample_interval;
 
   log_debug(gc, director)("Rule: Allocation Rate (Dynamic GC Workers), "
                           "MaxAllocRate: %.1fMB/s (+/-%.1f%%), Free: " SIZE_FORMAT "MB, GCCPUTime: %.3f, "


### PR DESCRIPTION
After the integration of ZGC dynamic thread selection, there was a regression that popped up on a few benchmarks that all had in common a high allocation rate and very quick GC times. An extra conservative measure for not trusting the heuristics when using few GC threads, did not play very well with this scenario. The effect of it is back-to-back GC causing thousands of GCs when <100 were really needed. Removing this conservative measure causes the regression to go away, and a bunch of green benchmarks to pop up instead of red ones. This suggest that conservative measure isn't working very well and does not scale to these scenarios. It is also already taken care of by other conservative measures. I propose it is removed, to solve the regressions.
The entire ZGC perf suite was rerun (no red, only green), and tier1-3 was run. There isn't much potential for things to blow up as I just removed one parameter in the heuristic. So if anything nasty was to show up, it would be in the perf runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271064](https://bugs.openjdk.java.net/browse/JDK-8271064): ZGC several jvm08 perf regressions after JDK-8268372


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/298.diff">https://git.openjdk.java.net/jdk17/pull/298.diff</a>

</details>
