### PR TITLE
8271877: ProblemList jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java in JDK17

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -830,7 +830,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java        8263461 linux-x64
+jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java        8263461 linux-all,windows-x64
 jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
 
 ############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java in JDK17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271877](https://bugs.openjdk.java.net/browse/JDK-8271877): ProblemList jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java in JDK17


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/299.diff">https://git.openjdk.java.net/jdk17/pull/299.diff</a>

</details>
