### PR TITLE
8271588: JFR Recorder Thread crashed with SIGSEGV in write_klass

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -455,7 +455,7 @@ size_t JfrCheckpointManager::flush_type_set() {
       elements = ::flush_type_set(thread);
     }
   }
-  if (_new_checkpoint.is_signaled()) {
+  if (_new_checkpoint.is_signaled_with_reset()) {
     WriteOperation wo(_chunkwriter);
     MutexedWriteOperation mwo(wo);
     _thread_local_mspace->iterate(mwo); // current epoch list

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -1103,6 +1103,10 @@ void JfrTypeSet::clear() {
 }
 
 size_t JfrTypeSet::on_unloading_classes(JfrCheckpointWriter* writer) {
+  // JfrTraceIdEpoch::has_changed_tag_state_no_reset() is a load-acquire we issue to see side-effects (i.e. tags).
+  // The JfrRecorderThread does this as part of normal processing, but with concurrent class unloading, which can
+  // happen in arbitrary threads, we invoke it explicitly.
+  JfrTraceIdEpoch::has_changed_tag_state_no_reset();
   if (JfrRecorder::is_recording()) {
     return serialize(writer, NULL, true, false);
   }

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
@@ -108,6 +108,10 @@ class JfrTraceIdEpoch : AllStatic {
   }
 
   static bool has_changed_tag_state() {
+    return _tag_state.is_signaled_with_reset();
+  }
+
+  static bool has_changed_tag_state_no_reset() {
     return _tag_state.is_signaled();
   }
 

--- a/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
+++ b/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
@@ -44,7 +44,7 @@ typedef JfrStringPool::BufferPtr BufferPtr;
 static JfrSignal _new_string;
 
 bool JfrStringPool::is_modified() {
-  return _new_string.is_signaled();
+  return _new_string.is_signaled_with_reset();
 }
 
 static JfrStringPool* _instance = NULL;

--- a/src/hotspot/share/jfr/utilities/jfrSignal.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSignal.hpp
@@ -34,14 +34,16 @@ class JfrSignal {
   JfrSignal() : _signaled(false) {}
 
   void signal() const {
-    if (!Atomic::load_acquire(&_signaled)) {
-      Atomic::release_store(&_signaled, true);
-    }
+    Atomic::release_store(&_signaled, true);
   }
 
   bool is_signaled() const {
-    if (Atomic::load_acquire(&_signaled)) {
-      Atomic::release_store(&_signaled, false); // auto-reset
+    return Atomic::load_acquire(&_signaled);
+  }
+
+  bool is_signaled_with_reset() const {
+    if (is_signaled()) {
+      Atomic::release_store(&_signaled, false);
       return true;
     }
     return false;


### PR DESCRIPTION
Greetings,

please help review this fix to better support concurrent class unloading.
Details in the JIRA issue.

Testing: jdk_jfr, stress

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271588](https://bugs.openjdk.java.net/browse/JDK-8271588): JFR Recorder Thread crashed with SIGSEGV in write_klass


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/301/head:pull/301` \
`$ git checkout pull/301`

Update a local copy of the PR: \
`$ git checkout pull/301` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 301`

View PR using the GUI difftool: \
`$ git pr show -t 301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/301.diff">https://git.openjdk.java.net/jdk17/pull/301.diff</a>

</details>
