### PR TITLE
    JDK-8272639: jpackaged applications using microphone on mac

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
@@ -139,7 +139,7 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
             if (Optional.ofNullable(
                     SIGN_BUNDLE.fetchFrom(params)).orElse(Boolean.FALSE)) {
                 // if signing bundle with app-image, warn user if app-image
-                // is not allready signed.
+                // is not already signed.
                 try {
                     if (!(AppImageFile.load(applicationImage).isSigned())) {
                         Log.info(MessageFormat.format(I18N.getString(

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Info-lite.plist.template
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/Info-lite.plist.template
@@ -33,5 +33,7 @@
   <string>DEPLOY_BUNDLE_COPYRIGHT</string>DEPLOY_FILE_ASSOCIATIONS
   <key>NSHighResolutionCapable</key>
   <string>true</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>The application DEPLOY_LAUNCHER_NAME is requesting access to the microphone.</string>
  </dict>
 </plist>

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/sandbox.plist
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/sandbox.plist
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
backport from jdk-18

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272639](https://bugs.openjdk.java.net/browse/JDK-8272639): jpackaged applications using microphone on mac ⚠️ Issue is not open.


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17 pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.java.net/jdk17 pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17/pull/306.diff">https://git.openjdk.java.net/jdk17/pull/306.diff</a>

</details>
